### PR TITLE
Updated Readme to refer to Calendar Sandbox rather than personal tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 In order to use the Cronofy API you will need to [create a developer account](https://app.cronofy.com/sign_up/new).
 
-From there you can [create personal access tokens](https://app.cronofy.com/oauth/applications/5447ae289bd94726da00000f/tokens)
+From there you can [Use your Calendar Sandbox](https://app.cronofy.com/oauth/sandbox)
 to access your own calendars, or you can [create an OAuth application](https://app.cronofy.com/oauth/applications/new)
 to obtain an OAuth `client_id` and `client_secret` to be able to use the full
 API.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-The Cronofy .NET SDK is available as a Nuget package
+The Cronofy .NET SDK is available as a Nuget package, to install run the following command in the [Package Manager Console](https://docs.nuget.org/consume/package-manager-console)
 ```
 Install-Package Cronofy
 ```


### PR DESCRIPTION
Merge when we release the Calendar Sandbox on the Developer Dashboard