### PR TITLE
Specify calendars for member availability

### DIFF
--- a/src/Cronofy/AvailabilityMemberBuilder.cs
+++ b/src/Cronofy/AvailabilityMemberBuilder.cs
@@ -20,6 +20,11 @@
         private IList<AvailabilityRequest.AvailablePeriod> availablePeriods;
 
         /// <summary>
+        /// The request's calendar IDs.
+        /// </summary>
+        private IEnumerable<string> calendarIds;
+
+        /// <summary>
         /// Sets the sub of the member.
         /// </summary>
         /// <param name="sub">
@@ -67,6 +72,47 @@
             return this;
         }
 
+        /// <summary>
+        /// Sets the calendar IDs for the request.
+        /// </summary>
+        /// <param name="calendarIds">
+        /// The calendar IDs to restrict the availability query to, must not be
+        /// null.
+        /// </param>
+        /// <returns>
+        /// A reference to the modified builder.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="calendarIds"/> is null.
+        /// </exception>
+        public AvailabilityMemberBuilder CalendarIds(IEnumerable<string> calendarIds)
+        {
+            Preconditions.NotNull("calendarIds", calendarIds);
+
+            this.calendarIds = calendarIds;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the calendar ID for the request.
+        /// </summary>
+        /// <param name="calendarId">
+        /// The calendar ID to restrict the availability query to, must not be
+        /// null.
+        /// </param>
+        /// <returns>
+        /// A reference to the modified builder.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="calendarId"/> is null.
+        /// </exception>
+        public AvailabilityMemberBuilder CalendarId(string calendarId)
+        {
+            Preconditions.NotNull("calendarId", calendarId);
+
+            return this.CalendarIds(new[] { calendarId });
+        }
+
         /// <inheritdoc />
         public AvailabilityRequest.Member Build()
         {
@@ -74,6 +120,7 @@
             {
                 Sub = this.sub,
                 AvailablePeriods = this.availablePeriods,
+                CalendarIds = this.calendarIds,
             };
         }
     }

--- a/src/Cronofy/Requests/AvailabilityRequest.cs
+++ b/src/Cronofy/Requests/AvailabilityRequest.cs
@@ -123,6 +123,15 @@
             /// </value>
             [JsonProperty("available_periods")]
             public IEnumerable<AvailablePeriod> AvailablePeriods { get; set; }
+
+            /// <summary>
+            /// Gets or sets the calendar IDs for the member.
+            /// </summary>
+            /// <value>
+            /// The calendar IDs for the request.
+            /// </value>
+            [JsonProperty("calendar_ids")]
+            public IEnumerable<string> CalendarIds { get; set; }
         }
     }
 }

--- a/test/Cronofy.Test/CronofyAccountClientTests/Availability.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/Availability.cs
@@ -137,6 +137,10 @@ namespace Cronofy.Test.CronofyAccountClientTests
                               ""start"": ""2017-01-03 09:00:00Z"",
                               ""end"": ""2017-01-03 12:00:00Z""
                             }
+                          ],
+                          ""calendar_ids"": [
+                            ""cal_1234_5678"",
+                            ""cal_9876_5432""
                           ]
                         }
                       ],
@@ -163,7 +167,8 @@ namespace Cronofy.Test.CronofyAccountClientTests
                 .Sub("acc_678347111010113")
                 .AddAvailablePeriod(
                     new DateTimeOffset(2017, 1, 3, 9, 0, 0, TimeSpan.Zero),
-                    new DateTimeOffset(2017, 1, 3, 12, 0, 0, TimeSpan.Zero));
+                    new DateTimeOffset(2017, 1, 3, 12, 0, 0, TimeSpan.Zero))
+                .CalendarIds(new[] { "cal_1234_5678", "cal_9876_5432" });
 
             var requiredGroup = new ParticipantGroupBuilder()
                 .AddMember("acc_567236000909002")


### PR DESCRIPTION
Allows the client to restrict events qualifying towards the member's availability to specific calendars.

#### Notes to reviewer

None.