### PR TITLE
Smart Invites multi attendees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## [0.22.0]
 
- * Allow setting of smart invite organizer name [#55]
+ * Allow setting of Smart Invite organizer name [#55]
 
 ## [0.21.0]
 
@@ -19,7 +19,7 @@
 
  * Application Calendar support [#49]
  * Add subject to oauth token responses [#53]
- * Added support for smart invite proposal [#52]
+ * Added support for Smart Invite proposal [#52]
 
 ## [0.19.1]
 

--- a/src/Cronofy/Cronofy.csproj
+++ b/src/Cronofy/Cronofy.csproj
@@ -164,6 +164,10 @@
     <Compile Include="Responses\SequencedAvailabilityResponse.cs" />
     <Compile Include="RealTimeSequencingRequestBuilder.cs" />
     <Compile Include="Responses\RealTimeSequencingResponse.cs" />
+    <Compile Include="SmartInviteMultiRecipientRequestBuilder.cs" />
+    <Compile Include="Requests\SmartInviteMultiRecipientRequest.cs" />
+    <Compile Include="SmartInviteMultiRecipient.cs" />
+    <Compile Include="Responses\SmartInviteMultiRecipientResponse.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages/StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets" />

--- a/src/Cronofy/CronofyOAuthClient.cs
+++ b/src/Cronofy/CronofyOAuthClient.cs
@@ -1,4 +1,4 @@
-﻿namespace Cronofy
+namespace Cronofy
 {
     using System;
     using System.Collections.Generic;
@@ -301,18 +301,7 @@
             }
         }
 
-        /// <summary>
-        /// Creates a smart invite for the given request.
-        /// </summary>
-        /// <param name="smartInviteRequest">
-        /// The details of the invite, must not be <code>null</code>.
-        /// </param>
-        /// <returns>
-        /// A smart invite for the given request.
-        /// </returns>
-        /// <exception cref="CronofyException">
-        /// Thrown if an error is encountered whilst making the request.
-        /// </exception>
+        /// <inheritdoc/>
         public SmartInvite CreateInvite(SmartInviteRequest smartInviteRequest)
         {
             var request = new HttpRequest
@@ -328,17 +317,7 @@
             return response.ToSmartInvite();
         }
 
-        /// <summary>
-        /// Cancels a smart invite for the given request.
-        /// </summary>
-        /// <param name="smartInviteId">The invite id to cancel.</param>
-        /// <param name="recipientEmail">The recipient for the cancellation.</param>
-        /// <returns>
-        /// A smart invite for the given request.
-        /// </returns>
-        /// <exception cref="CronofyException">
-        /// Thrown if an error is encountered whilst making the request.
-        /// </exception>
+        /// <inheritdoc/>
         public SmartInvite CancelInvite(string smartInviteId, string recipientEmail)
         {
             var request = new HttpRequest
@@ -356,21 +335,7 @@
             return response.ToSmartInvite();
         }
 
-        /// <summary>
-        /// Retreives detials of a smart invite.
-        /// </summary>
-        /// <param name="smartInviteId">
-        /// The invite id.
-        /// </param>
-        /// <param name="emailAddress">
-        /// The email address of the invitee.
-        /// </param>
-        /// <returns>
-        /// A smart invite for the given request.
-        /// </returns>
-        /// <exception cref="CronofyException">
-        /// Thrown if an error is encountered whilst making the request.
-        /// </exception>
+        /// <inheritdoc/>
         public SmartInvite GetSmartInvite(string smartInviteId, string emailAddress)
         {
             var request = new HttpRequest

--- a/src/Cronofy/CronofyOAuthClient.cs
+++ b/src/Cronofy/CronofyOAuthClient.cs
@@ -320,6 +320,9 @@ namespace Cronofy
         /// <inheritdoc/>
         public SmartInvite CancelInvite(string smartInviteId, string recipientEmail)
         {
+            Preconditions.NotEmpty("smartInviteId", smartInviteId);
+            Preconditions.NotEmpty("emailAddress", recipientEmail);
+
             var request = new HttpRequest
             {
                 Method = "POST",
@@ -338,6 +341,9 @@ namespace Cronofy
         /// <inheritdoc/>
         public SmartInvite GetSmartInvite(string smartInviteId, string emailAddress)
         {
+            Preconditions.NotEmpty("smartInviteId", smartInviteId);
+            Preconditions.NotEmpty("emailAddress", emailAddress);
+
             var request = new HttpRequest
             {
                 Method = "GET",
@@ -352,6 +358,43 @@ namespace Cronofy
             request.AddOAuthAuthorization(this.clientSecret);
 
             var response = this.HttpClient.GetJsonResponse<SmartInviteResponse>(request);
+            return response.ToSmartInvite();
+        }
+
+        /// <inheritdoc/>
+        public SmartInviteMultiRecipient CreateInvite(SmartInviteMultiRecipientRequest smartInviteRequest)
+        {
+            var request = new HttpRequest
+            {
+                Method = "POST",
+                Url = this.urlProvider.SmartInviteUrl
+            };
+
+            request.AddOAuthAuthorization(this.clientSecret);
+            request.SetJsonBody(smartInviteRequest);
+
+            var response = this.HttpClient.GetJsonResponse<SmartInviteMultiRecipientResponse>(request);
+            return response.ToSmartInvite();
+        }
+
+        /// <inheritdoc/>
+        public SmartInviteMultiRecipient GetSmartInvite(string smartInviteId)
+        {
+            Preconditions.NotEmpty("smartInviteId", smartInviteId);
+
+            var request = new HttpRequest
+            {
+                Method = "GET",
+                Url = this.urlProvider.SmartInviteUrl,
+                QueryString = new HttpRequest.QueryStringCollection
+                {
+                    { "smart_invite_id", smartInviteId }
+                }
+            };
+
+            request.AddOAuthAuthorization(this.clientSecret);
+
+            var response = this.HttpClient.GetJsonResponse<SmartInviteMultiRecipientResponse>(request);
             return response.ToSmartInvite();
         }
 

--- a/src/Cronofy/ICronofyOAuthClient.cs
+++ b/src/Cronofy/ICronofyOAuthClient.cs
@@ -1,4 +1,4 @@
-﻿namespace Cronofy
+namespace Cronofy
 {
     using System;
     using Cronofy.Requests;
@@ -138,5 +138,49 @@
         /// Thrown if <paramref name="realTimeSequencingRequest"/> is null.
         /// </exception>
         string RealTimeSequencing(RealTimeSequencingRequest realTimeSequencingRequest);
+
+        /// <summary>
+        /// Creates a smart invite for the given request.
+        /// </summary>
+        /// <param name="smartInviteRequest">
+        /// The details of the invite, must not be <code>null</code>.
+        /// </param>
+        /// <returns>
+        /// A smart invite for the given request.
+        /// </returns>
+        /// <exception cref="CronofyException">
+        /// Thrown if an error is encountered whilst making the request.
+        /// </exception>
+        SmartInvite CreateInvite(SmartInviteRequest smartInviteRequest);
+
+        /// <summary>
+        /// Cancels a smart invite for the given request.
+        /// </summary>
+        /// <param name="smartInviteId">The invite id to cancel.</param>
+        /// <param name="recipientEmail">The recipient for the cancellation.</param>
+        /// <returns>
+        /// A smart invite for the given request.
+        /// </returns>
+        /// <exception cref="CronofyException">
+        /// Thrown if an error is encountered whilst making the request.
+        /// </exception>
+        SmartInvite CancelInvite(string smartInviteId, string recipientEmail);
+
+        /// <summary>
+        /// Retreives detials of a smart invite.
+        /// </summary>
+        /// <param name="smartInviteId">
+        /// The invite id.
+        /// </param>
+        /// <param name="emailAddress">
+        /// The email address of the invitee.
+        /// </param>
+        /// <returns>
+        /// A smart invite for the given request.
+        /// </returns>
+        /// <exception cref="CronofyException">
+        /// Thrown if an error is encountered whilst making the request.
+        /// </exception>
+        SmartInvite GetSmartInvite(string smartInviteId, string emailAddress);
     }
 }

--- a/src/Cronofy/ICronofyOAuthClient.cs
+++ b/src/Cronofy/ICronofyOAuthClient.cs
@@ -140,13 +140,13 @@ namespace Cronofy
         string RealTimeSequencing(RealTimeSequencingRequest realTimeSequencingRequest);
 
         /// <summary>
-        /// Creates a smart invite for the given request.
+        /// Creates a Smart Invite for the given request.
         /// </summary>
         /// <param name="smartInviteRequest">
         /// The details of the invite, must not be <code>null</code>.
         /// </param>
         /// <returns>
-        /// A smart invite for the given request.
+        /// A Smart Invite for the given request.
         /// </returns>
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
@@ -154,12 +154,12 @@ namespace Cronofy
         SmartInvite CreateInvite(SmartInviteRequest smartInviteRequest);
 
         /// <summary>
-        /// Cancels a smart invite for the given request.
+        /// Cancels a Smart Invite for the given request.
         /// </summary>
         /// <param name="smartInviteId">The invite id to cancel.</param>
         /// <param name="recipientEmail">The recipient for the cancellation.</param>
         /// <returns>
-        /// A smart invite for the given request.
+        /// A Smart Invite for the given request.
         /// </returns>
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
@@ -167,7 +167,7 @@ namespace Cronofy
         SmartInvite CancelInvite(string smartInviteId, string recipientEmail);
 
         /// <summary>
-        /// Retreives detials of a smart invite.
+        /// Retreives details of a Smart Invite.
         /// </summary>
         /// <param name="smartInviteId">
         /// The invite id.
@@ -176,11 +176,39 @@ namespace Cronofy
         /// The email address of the invitee.
         /// </param>
         /// <returns>
-        /// A smart invite for the given request.
+        /// A Smart Invite for the given request.
         /// </returns>
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
         SmartInvite GetSmartInvite(string smartInviteId, string emailAddress);
+
+        /// <summary>
+        /// Creates a Smart Invite for the given request.
+        /// </summary>
+        /// <param name="smartInviteRequest">
+        /// The details of the invite, must not be <code>null</code>.
+        /// </param>
+        /// <returns>
+        /// A Smart Invite for the given request.
+        /// </returns>
+        /// <exception cref="CronofyException">
+        /// Thrown if an error is encountered whilst making the request.
+        /// </exception>
+        SmartInviteMultiRecipient CreateInvite(SmartInviteMultiRecipientRequest smartInviteRequest);
+
+        /// <summary>
+        /// Retreives details of a Smart Invite.
+        /// </summary>
+        /// <param name="smartInviteId">
+        /// The invite id.
+        /// </param>
+        /// <returns>
+        /// A Smart Invite for the given request.
+        /// </returns>
+        /// <exception cref="CronofyException">
+        /// Thrown if an error is encountered whilst making the request.
+        /// </exception>
+        SmartInviteMultiRecipient GetSmartInvite(string smartInviteId);
     }
 }

--- a/src/Cronofy/Requests/SmartInviteCancelRequest.cs
+++ b/src/Cronofy/Requests/SmartInviteCancelRequest.cs
@@ -3,14 +3,14 @@
     using Newtonsoft.Json;
 
     /// <summary>
-    /// Class for the serialization of an smart invite cancel request.
+    /// Class for the serialization of an Smart Invite cancel request.
     /// </summary>
     public sealed class SmartInviteCancelRequest
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Cronofy.Requests.SmartInviteCancelRequest"/> class.
         /// </summary>
-        /// <param name="smartInviteId">The smart invite identifier.</param>
+        /// <param name="smartInviteId">The Smart Invite identifier.</param>
         /// <param name="recipientEmail">The recipient email.</param>
         public SmartInviteCancelRequest(string smartInviteId, string recipientEmail)
         {
@@ -50,7 +50,7 @@
         public InviteRecipient Recipient { get; set; }
 
         /// <summary>
-        /// Class for the serialization of an smart invite request recipient.
+        /// Class for the serialization of an Smart Invite request recipient.
         /// </summary>
         public sealed class InviteRecipient
         {

--- a/src/Cronofy/Requests/SmartInviteEventRequest.cs
+++ b/src/Cronofy/Requests/SmartInviteEventRequest.cs
@@ -1,7 +1,7 @@
 ﻿namespace Cronofy.Requests
 {
     /// <summary>
-    /// Class to represent a smart invite event.
+    /// Class to represent a Smart Invite event.
     /// </summary>
     public sealed class SmartInviteEventRequest : BaseEventRequest
     {

--- a/src/Cronofy/Requests/SmartInviteMultiRecipientRequest.cs
+++ b/src/Cronofy/Requests/SmartInviteMultiRecipientRequest.cs
@@ -6,7 +6,7 @@ namespace Cronofy.Requests
     /// <summary>
     /// Class for the serialization of an smart invite request.
     /// </summary>
-    public sealed class SmartInviteRequest
+    public sealed class SmartInviteMultiRecipientRequest
     {
         /// <summary>
         /// Gets or sets the method for the invite.
@@ -36,13 +36,13 @@ namespace Cronofy.Requests
         public string CallbackUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the recipient for the invite.
+        /// Gets or sets the recipients for the invite.
         /// </summary>
         /// <value>
-        /// The recipient for the invite.
+        /// The recipients for the invite.
         /// </value>
-        [JsonProperty("recipient")]
-        public InviteRecipient Recipient { get; set; }
+        [JsonProperty("recipients")]
+        public IEnumerable<InviteRecipient> Recipients { get; set; }
 
         /// <summary>
         /// Gets or sets the details for the event.

--- a/src/Cronofy/Requests/SmartInviteMultiRecipientRequest.cs
+++ b/src/Cronofy/Requests/SmartInviteMultiRecipientRequest.cs
@@ -1,10 +1,10 @@
-namespace Cronofy.Requests
+﻿namespace Cronofy.Requests
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
     /// <summary>
-    /// Class for the serialization of an smart invite request.
+    /// Class for the serialization of an Smart Invite request.
     /// </summary>
     public sealed class SmartInviteMultiRecipientRequest
     {
@@ -63,7 +63,7 @@ namespace Cronofy.Requests
         public InviteOrganizer Organizer { get; set; }
 
         /// <summary>
-        /// Class for the serialization of an smart invite request recipient.
+        /// Class for the serialization of an Smart Invite request recipient.
         /// </summary>
         public sealed class InviteRecipient
         {
@@ -78,7 +78,7 @@ namespace Cronofy.Requests
         }
 
         /// <summary>
-        /// Class for the serialization of an smart invite request organizer.
+        /// Class for the serialization of an Smart Invite request organizer.
         /// </summary>
         public sealed class InviteOrganizer
         {

--- a/src/Cronofy/Requests/SmartInviteRequest.cs
+++ b/src/Cronofy/Requests/SmartInviteRequest.cs
@@ -1,5 +1,6 @@
-﻿namespace Cronofy.Requests
+namespace Cronofy.Requests
 {
+    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -42,6 +43,15 @@
         /// </value>
         [JsonProperty("recipient")]
         public InviteRecipient Recipient { get; set; }
+
+        /// <summary>
+        /// Gets or sets the recipients for the invite.
+        /// </summary>
+        /// <value>
+        /// The recipients for the invite.
+        /// </value>
+        [JsonProperty("recipients")]
+        public IEnumerable<InviteRecipient> Recipients { get; set; }
 
         /// <summary>
         /// Gets or sets the details for the event.

--- a/src/Cronofy/Requests/SmartInviteRequest.cs
+++ b/src/Cronofy/Requests/SmartInviteRequest.cs
@@ -1,10 +1,10 @@
-namespace Cronofy.Requests
+﻿namespace Cronofy.Requests
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
     /// <summary>
-    /// Class for the serialization of an smart invite request.
+    /// Class for the serialization of an Smart Invite request.
     /// </summary>
     public sealed class SmartInviteRequest
     {
@@ -63,7 +63,7 @@ namespace Cronofy.Requests
         public InviteOrganizer Organizer { get; set; }
 
         /// <summary>
-        /// Class for the serialization of an smart invite request recipient.
+        /// Class for the serialization of an Smart Invite request recipient.
         /// </summary>
         public sealed class InviteRecipient
         {
@@ -78,7 +78,7 @@ namespace Cronofy.Requests
         }
 
         /// <summary>
-        /// Class for the serialization of an smart invite request organizer.
+        /// Class for the serialization of an Smart Invite request organizer.
         /// </summary>
         public sealed class InviteOrganizer
         {

--- a/src/Cronofy/Responses/SmartInviteMultiRecipientResponse.cs
+++ b/src/Cronofy/Responses/SmartInviteMultiRecipientResponse.cs
@@ -1,0 +1,83 @@
+namespace Cronofy.Responses
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Class to represent a smart invite response.
+    /// </summary>
+    internal sealed class SmartInviteMultiRecipientResponse
+    {
+        /// <summary>
+        /// Gets or sets the method for the invite.
+        /// </summary>
+        /// <value>
+        /// The method of the invite.
+        /// </value>
+        [JsonProperty("method")]
+        public string Method { get; set; }
+
+        /// <summary>
+        /// Gets or sets the smart invite identifier.
+        /// </summary>
+        /// <value>The smart invite identifier.</value>
+        [JsonProperty("smart_invite_id")]
+        public string SmartInviteId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the callback URL.
+        /// </summary>
+        /// <value>The callback URL.</value>
+        [JsonProperty("callback_url")]
+        public string CallbackUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the recipients list.
+        /// </summary>
+        /// <value>The recipient.</value>
+        [JsonProperty("recipients")]
+        public SmartInviteResponse.ResponseAttendee[] Recipients { get; set; }
+
+        /// <summary>
+        /// Gets or sets the event.
+        /// </summary>
+        /// <value>The event.</value>
+        [JsonProperty("event")]
+        public ReadEventsResponse.EventResponse Event { get; set; }
+
+        /// <summary>
+        /// Gets or sets the attachments.
+        /// </summary>
+        /// <value>The attachments.</value>
+        [JsonProperty("attachments")]
+        public SmartInviteResponse.AttachmentsResponse Attachments { get; set; }
+
+        /// <summary>
+        /// Converts this response to a SmartInviteMultiRecipient object.
+        /// </summary>
+        /// <returns>A Smart invite object.</returns>
+        public SmartInviteMultiRecipient ToSmartInvite()
+        {
+            var invite = new SmartInviteMultiRecipient();
+
+            invite.SmartInviteId = this.SmartInviteId;
+            invite.CallbackUrl = this.CallbackUrl;
+            invite.Method = this.Method;
+
+            if (this.Recipients != null)
+            {
+                invite.Recipients = this.Recipients.Select(t => t.ToAttendee());
+            }
+            else
+            {
+                invite.Recipients = Enumerable.Empty<SmartInvite.Attendee>();
+            }
+
+            invite.Event = this.Event.ToEvent();
+            invite.Attachments = this.Attachments.ToAttachments();
+
+            return invite;
+        }
+    }
+}

--- a/src/Cronofy/Responses/SmartInviteMultiRecipientResponse.cs
+++ b/src/Cronofy/Responses/SmartInviteMultiRecipientResponse.cs
@@ -1,11 +1,11 @@
-namespace Cronofy.Responses
+﻿namespace Cronofy.Responses
 {
     using System.Collections.Generic;
     using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
-    /// Class to represent a smart invite response.
+    /// Class to represent a Smart Invite response.
     /// </summary>
     internal sealed class SmartInviteMultiRecipientResponse
     {
@@ -19,9 +19,9 @@ namespace Cronofy.Responses
         public string Method { get; set; }
 
         /// <summary>
-        /// Gets or sets the smart invite identifier.
+        /// Gets or sets the Smart Invite identifier.
         /// </summary>
-        /// <value>The smart invite identifier.</value>
+        /// <value>The Smart Invite identifier.</value>
         [JsonProperty("smart_invite_id")]
         public string SmartInviteId { get; set; }
 

--- a/src/Cronofy/Responses/SmartInviteResponse.cs
+++ b/src/Cronofy/Responses/SmartInviteResponse.cs
@@ -1,5 +1,6 @@
-﻿namespace Cronofy.Responses
+namespace Cronofy.Responses
 {
+    using System.Collections.Generic;
     using System.Linq;
     using Newtonsoft.Json;
 
@@ -46,6 +47,13 @@
         public ResponseAttendee Recipient { get; set; }
 
         /// <summary>
+        /// Gets or sets the recipients list.
+        /// </summary>
+        /// <value>The recipient.</value>
+        [JsonProperty("recipients")]
+        public IEnumerable<ResponseAttendee> Recipients { get; set; }
+
+        /// <summary>
         /// Gets or sets the event.
         /// </summary>
         /// <value>The event.</value>
@@ -79,7 +87,20 @@
                 invite.Replies = Enumerable.Empty<SmartInvite.Attendee>();
             }
 
-            invite.Recipient = this.Recipient.ToAttendee();
+            if (this.Recipient != null)
+            {
+                invite.Recipient = this.Recipient.ToAttendee();
+            }
+
+            if(this.Recipients != null)
+            {
+                invite.Recipients = this.Recipients.Select(t => t.ToAttendee());
+            }
+            else
+            {
+                invite.Recipients = Enumerable.Empty<SmartInvite.Attendee>();
+            }
+
             invite.Event = this.Event.ToEvent();
             invite.Attachments = this.Attachments.ToAttachments();
 

--- a/src/Cronofy/Responses/SmartInviteResponse.cs
+++ b/src/Cronofy/Responses/SmartInviteResponse.cs
@@ -1,11 +1,11 @@
-namespace Cronofy.Responses
+﻿namespace Cronofy.Responses
 {
     using System.Collections.Generic;
     using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
-    /// Class to represent a smart invite response.
+    /// Class to represent a Smart Invite response.
     /// </summary>
     internal sealed class SmartInviteResponse
     {
@@ -19,9 +19,9 @@ namespace Cronofy.Responses
         public string Method { get; set; }
 
         /// <summary>
-        /// Gets or sets the smart invite identifier.
+        /// Gets or sets the Smart Invite identifier.
         /// </summary>
-        /// <value>The smart invite identifier.</value>
+        /// <value>The Smart Invite identifier.</value>
         [JsonProperty("smart_invite_id")]
         public string SmartInviteId { get; set; }
 

--- a/src/Cronofy/Responses/SmartInviteResponse.cs
+++ b/src/Cronofy/Responses/SmartInviteResponse.cs
@@ -47,13 +47,6 @@ namespace Cronofy.Responses
         public ResponseAttendee Recipient { get; set; }
 
         /// <summary>
-        /// Gets or sets the recipients list.
-        /// </summary>
-        /// <value>The recipient.</value>
-        [JsonProperty("recipients")]
-        public IEnumerable<ResponseAttendee> Recipients { get; set; }
-
-        /// <summary>
         /// Gets or sets the event.
         /// </summary>
         /// <value>The event.</value>
@@ -90,15 +83,6 @@ namespace Cronofy.Responses
             if (this.Recipient != null)
             {
                 invite.Recipient = this.Recipient.ToAttendee();
-            }
-
-            if (this.Recipients != null)
-            {
-                invite.Recipients = this.Recipients.Select(t => t.ToAttendee());
-            }
-            else
-            {
-                invite.Recipients = Enumerable.Empty<SmartInvite.Attendee>();
             }
 
             invite.Event = this.Event.ToEvent();

--- a/src/Cronofy/Responses/SmartInviteResponse.cs
+++ b/src/Cronofy/Responses/SmartInviteResponse.cs
@@ -92,7 +92,7 @@ namespace Cronofy.Responses
                 invite.Recipient = this.Recipient.ToAttendee();
             }
 
-            if(this.Recipients != null)
+            if (this.Recipients != null)
             {
                 invite.Recipients = this.Recipients.Select(t => t.ToAttendee());
             }

--- a/src/Cronofy/SmartInvite.cs
+++ b/src/Cronofy/SmartInvite.cs
@@ -1,22 +1,22 @@
-namespace Cronofy
+﻿namespace Cronofy
 {
     using System.Collections.Generic;
 
     /// <summary>
-    /// Class to represent a smart invite.
+    /// Class to represent a Smart Invite.
     /// </summary>
     public sealed class SmartInvite
     {
         /// <summary>
-        /// Gets or sets the method for the smart invite.
+        /// Gets or sets the method for the Smart Invite.
         /// </summary>
         /// <value>The method.</value>
         public string Method { get; set; }
 
         /// <summary>
-        /// Gets or sets the smart invite id.
+        /// Gets or sets the Smart Invite id.
         /// </summary>
-        /// <value>The smart invite id.</value>
+        /// <value>The Smart Invite id.</value>
         public string SmartInviteId { get; set; }
 
         /// <summary>

--- a/src/Cronofy/SmartInvite.cs
+++ b/src/Cronofy/SmartInvite.cs
@@ -1,4 +1,4 @@
-﻿namespace Cronofy
+namespace Cronofy
 {
     using System.Collections.Generic;
 
@@ -36,6 +36,12 @@
         /// </summary>
         /// <value>The primary recipient.</value>
         public Attendee Recipient { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current state of the recipients.
+        /// </summary>
+        /// <value>The recipients.</value>
+        public IEnumerable<Attendee> Recipients { get; set; }
 
         /// <summary>
         /// Gets or sets the event details for the invite.

--- a/src/Cronofy/SmartInviteEventRequestBuilder.cs
+++ b/src/Cronofy/SmartInviteEventRequestBuilder.cs
@@ -6,7 +6,7 @@
     using Cronofy.Requests;
 
     /// <summary>
-    /// Builder class for smart invite events.
+    /// Builder class for Smart Invite events.
     /// </summary>
     public sealed class SmartInviteEventRequestBuilder : IBuilder<SmartInviteEventRequest>
     {

--- a/src/Cronofy/SmartInviteMultiRecipient.cs
+++ b/src/Cronofy/SmartInviteMultiRecipient.cs
@@ -1,22 +1,22 @@
-namespace Cronofy
+﻿namespace Cronofy
 {
     using System.Collections.Generic;
 
     /// <summary>
-    /// Class to represent a smart invite.
+    /// Class to represent a Smart Invite.
     /// </summary>
     public sealed class SmartInviteMultiRecipient
     {
         /// <summary>
-        /// Gets or sets the method for the smart invite.
+        /// Gets or sets the method for the Smart Invite.
         /// </summary>
         /// <value>The method.</value>
         public string Method { get; set; }
 
         /// <summary>
-        /// Gets or sets the smart invite id.
+        /// Gets or sets the Smart Invite id.
         /// </summary>
-        /// <value>The smart invite id.</value>
+        /// <value>The Smart Invite id.</value>
         public string SmartInviteId { get; set; }
 
         /// <summary>

--- a/src/Cronofy/SmartInviteMultiRecipient.cs
+++ b/src/Cronofy/SmartInviteMultiRecipient.cs
@@ -1,0 +1,46 @@
+namespace Cronofy
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Class to represent a smart invite.
+    /// </summary>
+    public sealed class SmartInviteMultiRecipient
+    {
+        /// <summary>
+        /// Gets or sets the method for the smart invite.
+        /// </summary>
+        /// <value>The method.</value>
+        public string Method { get; set; }
+
+        /// <summary>
+        /// Gets or sets the smart invite id.
+        /// </summary>
+        /// <value>The smart invite id.</value>
+        public string SmartInviteId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the callback URL.
+        /// </summary>
+        /// <value>The callback url.</value>
+        public string CallbackUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current state of the recipients.
+        /// </summary>
+        /// <value>The recipients.</value>
+        public IEnumerable<SmartInvite.Attendee> Recipients { get; set; }
+
+        /// <summary>
+        /// Gets or sets the event details for the invite.
+        /// </summary>
+        /// <value>The event details.</value>
+        public Event Event { get; set; }
+
+        /// <summary>
+        /// Gets or sets the attachments for the invite.
+        /// </summary>
+        /// <value>The attachments.</value>
+        public SmartInvite.InviteAttachments Attachments { get; set; }
+    }
+}

--- a/src/Cronofy/SmartInviteMultiRecipientRequestBuilder.cs
+++ b/src/Cronofy/SmartInviteMultiRecipientRequestBuilder.cs
@@ -1,4 +1,4 @@
-namespace Cronofy
+﻿namespace Cronofy
 {
     using System;
     using System.Collections.Generic;
@@ -12,7 +12,7 @@ namespace Cronofy
     public sealed class SmartInviteMultiRecipientRequestBuilder : IBuilder<SmartInviteMultiRecipientRequest>
     {
         /// <summary>
-        /// The smart invite identifier.
+        /// The Smart Invite identifier.
         /// </summary>
         private string smartInviteId;
 
@@ -71,10 +71,10 @@ namespace Cronofy
         }
 
         /// <summary>
-        /// Sets the smart invite id.
+        /// Sets the Smart Invite id.
         /// </summary>
         /// <param name="smartInviteId">
-        /// The smart invite id.
+        /// The Smart Invite id.
         /// </param>
         /// <returns>
         /// A reference to the modified builder.

--- a/src/Cronofy/SmartInviteMultiRecipientRequestBuilder.cs
+++ b/src/Cronofy/SmartInviteMultiRecipientRequestBuilder.cs
@@ -6,10 +6,10 @@ namespace Cronofy
 
     /// <summary>
     /// Builder class for
-    /// <see cref="CronofyOAuthClient.CreateInvite(SmartInviteRequest)"/>
+    /// <see cref="ICronofyOAuthClient.CreateInvite(SmartInviteMultiRecipientRequest)"/>
     /// method calls.
     /// </summary>
-    public sealed class SmartInviteRequestBuilder : IBuilder<SmartInviteRequest>
+    public sealed class SmartInviteMultiRecipientRequestBuilder : IBuilder<SmartInviteMultiRecipientRequest>
     {
         /// <summary>
         /// The smart invite identifier.
@@ -32,21 +32,22 @@ namespace Cronofy
         private SmartInviteEventRequest inviteEvent;
 
         /// <summary>
-        /// The recipient.
+        /// The recipients.
         /// </summary>
-        private SmartInviteRequest.InviteRecipient recipient;
+        private IList<SmartInviteMultiRecipientRequest.InviteRecipient> recipients;
 
         /// <summary>
         /// The organizer.
         /// </summary>
-        private SmartInviteRequest.InviteOrganizer organizer;
+        private SmartInviteMultiRecipientRequest.InviteOrganizer organizer;
 
         /// <summary>
         /// Initializes a new instance of the
-        /// <see cref="Cronofy.SmartInviteRequestBuilder"/> class.
+        /// <see cref="Cronofy.SmartInviteMultiRecipientRequestBuilder"/> class.
         /// </summary>
-        public SmartInviteRequestBuilder()
+        public SmartInviteMultiRecipientRequestBuilder()
         {
+            this.recipients = new List<SmartInviteMultiRecipientRequest.InviteRecipient>();
         }
 
         /// <summary>
@@ -61,7 +62,7 @@ namespace Cronofy
         /// <exception cref="ArgumentException">
         /// Thrown if <paramref name="method"/> is empty.
         /// </exception>
-        public SmartInviteRequestBuilder Method(string method)
+        public SmartInviteMultiRecipientRequestBuilder Method(string method)
         {
             Preconditions.NotEmpty("method", method);
 
@@ -81,7 +82,7 @@ namespace Cronofy
         /// <exception cref="ArgumentException">
         /// Thrown if <paramref name="smartInviteId"/> is empty.
         /// </exception>
-        public SmartInviteRequestBuilder InviteId(string smartInviteId)
+        public SmartInviteMultiRecipientRequestBuilder InviteId(string smartInviteId)
         {
             Preconditions.NotEmpty("smartInviteId", smartInviteId);
 
@@ -101,7 +102,7 @@ namespace Cronofy
         /// <exception cref="ArgumentException">
         /// Thrown if <paramref name="callbackUrl"/> is empty.
         /// </exception>
-        public SmartInviteRequestBuilder CallbackUrl(string callbackUrl)
+        public SmartInviteMultiRecipientRequestBuilder CallbackUrl(string callbackUrl)
         {
             Preconditions.NotEmpty("callbackUrl", callbackUrl);
 
@@ -121,7 +122,7 @@ namespace Cronofy
         /// <exception cref="ArgumentException">
         /// Thrown if <paramref name="inviteEvent"/> is null.
         /// </exception>
-        public SmartInviteRequestBuilder Event(SmartInviteEventRequest inviteEvent)
+        public SmartInviteMultiRecipientRequestBuilder Event(SmartInviteEventRequest inviteEvent)
         {
             Preconditions.NotNull("inviteEvent", inviteEvent);
 
@@ -130,7 +131,7 @@ namespace Cronofy
         }
 
         /// <summary>
-        /// Sets the Recipient details.
+        /// Add a new recipient to the recipients list.
         /// </summary>
         /// <param name="email">
         /// The email address of the recipient.
@@ -141,14 +142,14 @@ namespace Cronofy
         /// <exception cref="ArgumentException">
         /// Thrown if <paramref name="email"/> is null.
         /// </exception>
-        public SmartInviteRequestBuilder Recipient(string email)
+        public SmartInviteMultiRecipientRequestBuilder AddRecipient(string email)
         {
             Preconditions.NotNull("email", email);
 
-            this.recipient = new SmartInviteRequest.InviteRecipient
+            this.recipients.Add(new SmartInviteMultiRecipientRequest.InviteRecipient
             {
                 Email = email
-            };
+            });
 
             return this;
         }
@@ -165,26 +166,27 @@ namespace Cronofy
         /// <exception cref="ArgumentException">
         /// Thrown if <paramref name="name"/> is null.
         /// </exception>
-        public SmartInviteRequestBuilder Organizer(string name)
+        public SmartInviteMultiRecipientRequestBuilder Organizer(string name)
         {
             Preconditions.NotNull("name", name);
 
-            this.organizer = new SmartInviteRequest.InviteOrganizer
+            this.organizer = new SmartInviteMultiRecipientRequest.InviteOrganizer
             {
                 Name = name
             };
+
             return this;
         }
 
         /// <inheritdoc/>
-        public SmartInviteRequest Build()
+        public SmartInviteMultiRecipientRequest Build()
         {
-            var request = new SmartInviteRequest()
+            var request = new SmartInviteMultiRecipientRequest()
             {
                 SmartInviteId = this.smartInviteId,
                 CallbackUrl = this.callbackUrl,
                 Event = this.inviteEvent,
-                Recipient = this.recipient,
+                Recipients = this.recipients,
             };
 
             if (this.organizer != null)

--- a/src/Cronofy/SmartInviteRequestBuilder.cs
+++ b/src/Cronofy/SmartInviteRequestBuilder.cs
@@ -37,7 +37,7 @@ namespace Cronofy
         private SmartInviteRequest.InviteRecipient recipient;
 
         /// <summary>
-        /// The recipients
+        /// The recipients.
         /// </summary>
         private IList<SmartInviteRequest.InviteRecipient> recipients;
 
@@ -159,7 +159,7 @@ namespace Cronofy
         }
 
         /// <summary>
-        /// Add a new recipient to the recipients list
+        /// Add a new recipient to the recipients list.
         /// </summary>
         /// <param name="email">
         /// The email address of the recipient.
@@ -179,7 +179,7 @@ namespace Cronofy
                 this.recipients = new List<SmartInviteRequest.InviteRecipient>();
             }
 
-            recipients.Add(new SmartInviteRequest.InviteRecipient
+            this.recipients.Add(new SmartInviteRequest.InviteRecipient
             {
                 Email = email
             });

--- a/src/Cronofy/SmartInviteRequestBuilder.cs
+++ b/src/Cronofy/SmartInviteRequestBuilder.cs
@@ -1,6 +1,7 @@
-﻿namespace Cronofy
+namespace Cronofy
 {
     using System;
+    using System.Collections.Generic;
     using Cronofy.Requests;
 
     /// <summary>
@@ -34,6 +35,11 @@
         /// The recipient.
         /// </summary>
         private SmartInviteRequest.InviteRecipient recipient;
+
+        /// <summary>
+        /// The recipients
+        /// </summary>
+        private IList<SmartInviteRequest.InviteRecipient> recipients;
 
         /// <summary>
         /// The organizer.
@@ -148,6 +154,36 @@
             {
                 Email = email
             };
+
+            return this;
+        }
+
+        /// <summary>
+        /// Add a new recipient to the recipients list
+        /// </summary>
+        /// <param name="email">
+        /// The email address of the recipient.
+        /// </param>
+        /// <returns>
+        /// A reference to the modified builder.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="email"/> is null.
+        /// </exception>
+        public SmartInviteRequestBuilder AddRecipient(string email)
+        {
+            Preconditions.NotNull("email", email);
+
+            if (this.recipients == null)
+            {
+                this.recipients = new List<SmartInviteRequest.InviteRecipient>();
+            }
+
+            recipients.Add(new SmartInviteRequest.InviteRecipient
+            {
+                Email = email
+            });
+
             return this;
         }
 
@@ -183,6 +219,7 @@
                 CallbackUrl = this.callbackUrl,
                 Event = this.inviteEvent,
                 Recipient = this.recipient,
+                Recipients = this.recipients
             };
 
             if (this.organizer != null)

--- a/src/Cronofy/SmartInviteRequestBuilder.cs
+++ b/src/Cronofy/SmartInviteRequestBuilder.cs
@@ -1,4 +1,4 @@
-namespace Cronofy
+﻿namespace Cronofy
 {
     using System;
     using System.Collections.Generic;
@@ -12,7 +12,7 @@ namespace Cronofy
     public sealed class SmartInviteRequestBuilder : IBuilder<SmartInviteRequest>
     {
         /// <summary>
-        /// The smart invite identifier.
+        /// The Smart Invite identifier.
         /// </summary>
         private string smartInviteId;
 
@@ -70,10 +70,10 @@ namespace Cronofy
         }
 
         /// <summary>
-        /// Sets the smart invite id.
+        /// Sets the Smart Invite id.
         /// </summary>
         /// <param name="smartInviteId">
-        /// The smart invite id.
+        /// The Smart Invite id.
         /// </param>
         /// <returns>
         /// A reference to the modified builder.

--- a/src/Cronofy/UrlProvider.cs
+++ b/src/Cronofy/UrlProvider.cs
@@ -1,4 +1,4 @@
-namespace Cronofy
+﻿namespace Cronofy
 {
     /// <summary>
     /// Class for providing URLs.
@@ -116,7 +116,7 @@ namespace Cronofy
         private const string RevokeProfileAuthorizationUrlFormatFormat = "https://api{0}.cronofy.com/v1/profiles/{{0}}/revoke";
 
         /// <summary>
-        /// The URL of the smart invite endpoint.
+        /// The URL of the Smart Invite endpoint.
         /// </summary>
         private const string SmartInviteUrlFormat = "https://api{0}.cronofy.com/v1/smart_invites";
 
@@ -449,9 +449,9 @@ namespace Cronofy
         }
 
         /// <summary>
-        /// Gets the smart invite URL.
+        /// Gets the Smart Invite URL.
         /// </summary>
-        /// <value>The smart invite url.</value>
+        /// <value>The Smart Invite url.</value>
         public string SmartInviteUrl { get; private set; }
 
         /// <summary>

--- a/test/Cronofy.Test/CronofyOAuthClientTests/SmartInvites.cs
+++ b/test/Cronofy.Test/CronofyOAuthClientTests/SmartInvites.cs
@@ -94,69 +94,6 @@ namespace Cronofy.Test.CronofyOAuthClientTests
         }
 
         [Test]
-        public void CanCreateMultiAttendeeInvite()
-        {
-            http.Stub(
-                HttpPost
-                    .Url("https://api.cronofy.com/v1/smart_invites")
-                    .RequestHeader("Authorization", string.Format("Bearer {0}", clientSecret))
-                    .RequestHeader("Content-Type", "application/json; charset=utf-8")
-                    .RequestBody(
-                        @"{""method"":""request"",""smart_invite_id"":""testEventId"",""callback_url"":""http://example.com/callbackUrl"",""recipients"":[{""email"":""cronofy@example.com""},{""email"":""cronofy2@example.com""}],""event"":{""summary"":""Test Summary"",""start"":{""time"":""2014-08-05 15:30:00Z"",""tzid"":""Etc/UTC""},""end"":{""time"":""2014-08-05 16:30:00Z"",""tzid"":""Etc/UTC""}},""organizer"":{""name"":""My Cool Application""}}")
-                    .ResponseCode(200)
-                    .ResponseBody(@"{
-                      ""recipients"": [
-                        {
-                            ""email"": ""cronofy@example.com"",
-                            ""status"": ""pending""
-                        },
-                        {
-                            ""email"": ""cronofy2@example.com"",
-                            ""status"": ""pending""
-                        }
-                      ],
-                      ""method"": ""request"",
-                      ""smart_invite_id"": ""your-unique-identifier-for-invite"",
-                      ""callback_url"": ""https://example.yourapp.com/cronofy/smart_invite/notifications"",
-                      ""event"": {
-                        ""summary"": ""Board meeting"",
-                        ""description"": ""Discuss plans for the next quarter."",
-                        ""start"": ""2017-10-05T09:30:00Z"",
-                        ""end"": ""2017-10-05T10:00:00Z"",
-                        ""tzid"": ""Europe/London"",
-                        ""location"": {
-                          ""description"": ""Board room""
-                        }
-                      },
-                      ""attachments"": {
-                        ""icalendar"": ""BEGIN:VCALENDAR\nVERSION:2.0...""
-                      }
-                    }")
-            );
-
-            var smartInviteRequest = new SmartInviteRequestBuilder()
-                .Method("request")
-                .CallbackUrl(callbackUrl)
-                .InviteId(inviteId)
-                .AddRecipient("cronofy@example.com")
-                .AddRecipient("cronofy2@example.com")
-                .Organizer("My Cool Application")
-                .Event(upsertEventRequest)
-                .Build();
-
-            var actual = client.CreateInvite(smartInviteRequest);
-
-            Assert.AreEqual("your-unique-identifier-for-invite", actual.SmartInviteId);
-            Assert.AreEqual("https://example.yourapp.com/cronofy/smart_invite/notifications", actual.CallbackUrl);
-            Assert.AreEqual("request", actual.Method);
-            Assert.AreEqual("cronofy@example.com", actual.Recipients.First().Email);
-            Assert.AreEqual("pending", actual.Recipients.First().Status);
-            Assert.AreEqual("cronofy2@example.com", actual.Recipients.Last().Email);
-            Assert.AreEqual("pending", actual.Recipients.Last().Status);
-            Assert.AreEqual("BEGIN:VCALENDAR\nVERSION:2.0...", actual.Attachments.ICalendar);
-        }
-
-        [Test]
         public void CanCancelInvite()
         {
             http.Stub(
@@ -278,5 +215,140 @@ namespace Cronofy.Test.CronofyOAuthClientTests
             Assert.AreEqual(new EventTime(new DateTimeOffset(2014, 9, 13, 23, 00, 00, TimeSpan.FromHours(2)), "Europe/Paris"), reply2.Proposal.End);
         }
 
+        [Test]
+        public void CanCreateMultiAttendeeInvite()
+        {
+            http.Stub(
+                HttpPost
+                    .Url("https://api.cronofy.com/v1/smart_invites")
+                    .RequestHeader("Authorization", string.Format("Bearer {0}", clientSecret))
+                    .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                    .RequestBody(
+                        @"{""method"":""request"",""smart_invite_id"":""testEventId"",""callback_url"":""http://example.com/callbackUrl"",""recipients"":[{""email"":""cronofy@example.com""},{""email"":""cronofy2@example.com""}],""event"":{""summary"":""Test Summary"",""start"":{""time"":""2014-08-05 15:30:00Z"",""tzid"":""Etc/UTC""},""end"":{""time"":""2014-08-05 16:30:00Z"",""tzid"":""Etc/UTC""}},""organizer"":{""name"":""My Cool Application""}}")
+                    .ResponseCode(200)
+                    .ResponseBody(@"{
+                      ""recipients"": [
+                        {
+                            ""email"": ""cronofy@example.com"",
+                            ""status"": ""pending""
+                        },
+                        {
+                            ""email"": ""cronofy2@example.com"",
+                            ""status"": ""pending""
+                        }
+                      ],
+                      ""method"": ""request"",
+                      ""smart_invite_id"": ""your-unique-identifier-for-invite"",
+                      ""callback_url"": ""https://example.yourapp.com/cronofy/smart_invite/notifications"",
+                      ""event"": {
+                        ""summary"": ""Board meeting"",
+                        ""description"": ""Discuss plans for the next quarter."",
+                        ""start"": ""2017-10-05T09:30:00Z"",
+                        ""end"": ""2017-10-05T10:00:00Z"",
+                        ""tzid"": ""Europe/London"",
+                        ""location"": {
+                          ""description"": ""Board room""
+                        }
+                      },
+                      ""attachments"": {
+                        ""icalendar"": ""BEGIN:VCALENDAR\nVERSION:2.0...""
+                      }
+                    }")
+            );
+
+            var smartInviteRequest = new SmartInviteMultiRecipientRequestBuilder()
+                .Method("request")
+                .CallbackUrl(callbackUrl)
+                .InviteId(inviteId)
+                .AddRecipient("cronofy@example.com")
+                .AddRecipient("cronofy2@example.com")
+                .Organizer("My Cool Application")
+                .Event(upsertEventRequest)
+                .Build();
+
+            var actual = client.CreateInvite(smartInviteRequest);
+
+            Assert.AreEqual("your-unique-identifier-for-invite", actual.SmartInviteId);
+            Assert.AreEqual("https://example.yourapp.com/cronofy/smart_invite/notifications", actual.CallbackUrl);
+            Assert.AreEqual("request", actual.Method);
+            Assert.AreEqual("cronofy@example.com", actual.Recipients.First().Email);
+            Assert.AreEqual("pending", actual.Recipients.First().Status);
+            Assert.AreEqual("cronofy2@example.com", actual.Recipients.Last().Email);
+            Assert.AreEqual("pending", actual.Recipients.Last().Status);
+            Assert.AreEqual("BEGIN:VCALENDAR\nVERSION:2.0...", actual.Attachments.ICalendar);
+        }
+
+
+        [Test]
+        public void CanGetMultiRecipientEventDetails()
+        {
+            http.Stub(
+                HttpGet
+                    .Url("https://api.cronofy.com/v1/smart_invites?smart_invite_id=example-event-id")
+                    .RequestHeader("Authorization", string.Format("Bearer {0}", clientSecret))
+                    .ResponseCode(200)
+                    .ResponseBody(@"{
+                      ""recipients"": [
+                       {
+                         ""email"": ""person1@example.com"",
+                         ""status"": ""accepted""
+                       },
+                       {
+                         ""email"": ""person2@example.com"",
+                         ""status"": ""declined"",
+                         ""comment"": ""example comment"",
+                         ""proposal"": {
+                            ""start"": {
+                              ""time"": ""2014-09-13T23:00:00+02:00"",
+                              ""tzid"": ""Europe/Paris""
+                            },
+                            ""end"": {
+                              ""time"": ""2014-09-13T23:00:00+02:00"",
+                              ""tzid"": ""Europe/Paris""
+                            }
+                          }
+                       }
+                      ],
+                      ""smart_invite_id"": ""your-unique-identifier-for-invite"",
+                      ""callback_url"": ""https://example.yourapp.com/cronofy/smart_invite/notifications"",
+                      ""method"": ""request"",
+                      ""event"": {
+                        ""summary"": ""Board meeting"",
+                        ""description"": ""Discuss plans for the next quarter."",
+                        ""start"": ""2017-10-05T09:30:00Z"",
+                        ""end"": ""2017-10-05T10:00:00Z"",
+                        ""tzid"": ""Europe/London"",
+                        ""location"": {
+                          ""description"": ""Board room""
+                        }
+                      },
+                      ""attachments"": {
+                        ""icalendar"": ""BEGIN:VCALENDAR\nVERSION:2.0...""
+                      }
+                    }")
+            );
+
+            var actual = client.GetSmartInvite("example-event-id");
+
+            Assert.AreEqual("your-unique-identifier-for-invite", actual.SmartInviteId);
+            Assert.AreEqual("https://example.yourapp.com/cronofy/smart_invite/notifications", actual.CallbackUrl);
+            Assert.AreEqual("request", actual.Method);
+            Assert.AreEqual("BEGIN:VCALENDAR\nVERSION:2.0...", actual.Attachments.ICalendar);
+
+            Assert.AreEqual(2, actual.Recipients.Count());
+
+            var reply1 = actual.Recipients.First();
+            Assert.NotNull(reply1);
+            Assert.AreEqual("person1@example.com", reply1.Email);
+            Assert.AreEqual("accepted", reply1.Status);
+
+            var reply2 = actual.Recipients.Last();
+            Assert.NotNull(reply2);
+            Assert.AreEqual("person2@example.com", reply2.Email);
+            Assert.AreEqual("declined", reply2.Status);
+            Assert.AreEqual("example comment", reply2.Comment);
+            Assert.AreEqual(new EventTime(new DateTimeOffset(2014, 9, 13, 23, 00, 00, TimeSpan.FromHours(2)), "Europe/Paris"), reply2.Proposal.Start);
+            Assert.AreEqual(new EventTime(new DateTimeOffset(2014, 9, 13, 23, 00, 00, TimeSpan.FromHours(2)), "Europe/Paris"), reply2.Proposal.End);
+        }
     }
 }


### PR DESCRIPTION
Supercedes #61

As the initial implementation of Smart Invites and the multi-recipient version differ significantly in terms of data structure, it feels better for them to be different builders and objects within the SDK to avoid the possibility of the methods being mixed, having to check for nulls, etc.