### PR TITLE
Rename Event.EventStatus property to Event.Status

### DIFF
--- a/src/Cronofy/Cronofy.csproj
+++ b/src/Cronofy/Cronofy.csproj
@@ -97,7 +97,6 @@
     <Compile Include="IHttpClientExtensions.cs" />
     <Compile Include="IBuilder.cs" />
     <Compile Include="CronofyException.cs" />
-    <Compile Include="Properties\AssemblyVersion.cs" />
     <Compile Include="GetEventsRequestBuilder.cs" />
     <Compile Include="Requests\GetEventsRequest.cs" />
     <Compile Include="CronofyResponseException.cs" />

--- a/src/Cronofy/Event.cs
+++ b/src/Cronofy/Event.cs
@@ -116,6 +116,27 @@ namespace Cronofy
         public string Transparency { get; set; }
 
         /// <summary>
+        /// Gets or sets <see cref="Event"/>.
+        /// This property is deprecated and kept for backwards compatibility.
+        /// </summary>
+        /// <value>
+        /// The same as <see cref="Status"/>.
+        /// </value>
+        [Obsolete]
+        public string EventStatus
+        {
+            get
+            {
+                return this.Status;
+            }
+
+            set
+            {
+                this.Status = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the status of the event.
         /// </summary>
         /// <value>
@@ -124,7 +145,7 @@ namespace Cronofy
         /// <remarks>
         /// See <see cref="Cronofy.EventStatus"/> for potential values.
         /// </remarks>
-        public string EventStatus { get; set; }
+        public string Status { get; set; }
 
         /// <summary>
         /// Gets or sets the categories assigned to the event.
@@ -245,7 +266,7 @@ namespace Cronofy
                 && this.Description == other.Description
                 && this.ParticipationStatus == other.ParticipationStatus
                 && this.Transparency == other.Transparency
-                && this.EventStatus == other.EventStatus
+                && this.Status == other.Status
                 && this.Recurring == other.Recurring
                 && this.MeetingUrl == other.MeetingUrl
                 && object.Equals(this.Organizer, other.Organizer)

--- a/src/Cronofy/Responses/ReadEventsResponse.cs
+++ b/src/Cronofy/Responses/ReadEventsResponse.cs
@@ -170,8 +170,8 @@
             /// <value>
             /// The status of the event.
             /// </value>
-            [JsonProperty("event_status")]
-            public string EventStatus { get; set; }
+            [JsonProperty("status")]
+            public string Status { get; set; }
 
             /// <summary>
             /// Gets or sets the categories assigned to the event.
@@ -268,7 +268,7 @@
                     Deleted = this.Deleted,
                     ParticipationStatus = this.ParticipationStatus,
                     Transparency = this.Transparency,
-                    EventStatus = this.EventStatus,
+                    Status = this.Status,
                     Categories = this.Categories,
                     Created = this.Created,
                     Updated = this.Updated,

--- a/test/Cronofy.Test/CronofyAccountClientTests/GetEvents.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/GetEvents.cs
@@ -49,7 +49,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
       ""recurring"": true,
       ""participation_status"": ""needs_action"",
       ""transparency"": ""opaque"",
-      ""event_status"": ""confirmed"",
+      ""status"": ""confirmed"",
       ""categories"": [],
       ""attendees"": [
         {
@@ -85,7 +85,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
                         Recurring = true,
                         ParticipationStatus = AttendeeStatus.NeedsAction,
                         Transparency = Transparency.Opaque,
-                        EventStatus = EventStatus.Confirmed,
+                        Status = EventStatus.Confirmed,
                         Categories = new string[] {},
                         Created = new DateTime(2014, 9, 1, 8, 0, 1, DateTimeKind.Utc),
                         Updated = new DateTime(2014, 9, 1, 9, 24, 16, DateTimeKind.Utc),
@@ -132,7 +132,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
       ""recurring"": true,
       ""participation_status"": ""needs_action"",
       ""transparency"": ""opaque"",
-      ""event_status"": ""confirmed"",
+      ""status"": ""confirmed"",
       ""categories"": [],
       ""location"": {
         ""description"": ""The Country"",
@@ -173,7 +173,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
                         Recurring = true,
                         ParticipationStatus = AttendeeStatus.NeedsAction,
                         Transparency = Transparency.Opaque,
-                        EventStatus = EventStatus.Confirmed,
+                        Status = EventStatus.Confirmed,
                         Categories = new string[] {},
                         Created = new DateTime(2014, 9, 1, 8, 0, 1, DateTimeKind.Utc),
                         Updated = new DateTime(2014, 9, 1, 9, 24, 16, DateTimeKind.Utc),
@@ -220,7 +220,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
       ""recurring"": true,
       ""participation_status"": ""needs_action"",
       ""transparency"": ""transparent"",
-      ""event_status"": ""confirmed"",
+      ""status"": ""confirmed"",
       ""categories"": [],
       ""attendees"": [
         {
@@ -256,7 +256,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
                         Recurring = true,
                         ParticipationStatus = AttendeeStatus.NeedsAction,
                         Transparency = Transparency.Transparent,
-                        EventStatus = EventStatus.Confirmed,
+                        Status = EventStatus.Confirmed,
                         Categories = new string[] {},
                         Created = new DateTime(2014, 9, 1, 8, 0, 1, DateTimeKind.Utc),
                         Updated = new DateTime(2014, 9, 1, 9, 24, 16, DateTimeKind.Utc),
@@ -303,7 +303,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
       ""recurring"": true,
       ""participation_status"": ""needs_action"",
       ""transparency"": ""transparent"",
-      ""event_status"": ""confirmed"",
+      ""status"": ""confirmed"",
       ""categories"": [],
       ""attendees"": [
         {
@@ -340,7 +340,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
                         Recurring = true,
                         ParticipationStatus = AttendeeStatus.NeedsAction,
                         Transparency = Transparency.Transparent,
-                        EventStatus = EventStatus.Confirmed,
+                        Status = EventStatus.Confirmed,
                         Categories = new string[] {},
                         Created = new DateTime(2014, 9, 1, 8, 0, 1, DateTimeKind.Utc),
                         Updated = new DateTime(2014, 9, 1, 9, 24, 16, DateTimeKind.Utc),
@@ -387,7 +387,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
       ""deleted"": false,
       ""participation_status"": ""needs_action"",
       ""transparency"": ""opaque"",
-      ""event_status"": ""confirmed"",
+      ""status"": ""confirmed"",
       ""categories"": [],
       ""attendees"": [
         {
@@ -418,7 +418,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
                     Deleted = false,
                     ParticipationStatus = AttendeeStatus.NeedsAction,
                     Transparency = Transparency.Opaque,
-                    EventStatus = EventStatus.Confirmed,
+                    Status = EventStatus.Confirmed,
                     Categories = new string[] {},
                     Created = DateTime.MinValue.ToUniversalTime(),
                     Updated = DateTime.MinValue.ToUniversalTime(),
@@ -461,7 +461,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
       ""recurring"": true,
       ""participation_status"": ""needs_action"",
       ""transparency"": ""transparent"",
-      ""event_status"": ""confirmed"",
+      ""status"": ""confirmed"",
       ""categories"": [],
       ""attendees"": [
         {
@@ -504,7 +504,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
                         Recurring = true,
                         ParticipationStatus = AttendeeStatus.NeedsAction,
                         Transparency = Transparency.Transparent,
-                        EventStatus = EventStatus.Confirmed,
+                        Status = EventStatus.Confirmed,
                         Categories = new string[] {},
                         Created = new DateTime(2014, 9, 1, 8, 0, 1, DateTimeKind.Utc),
                         Updated = new DateTime(2014, 9, 1, 9, 24, 16, DateTimeKind.Utc),
@@ -551,7 +551,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
       ""deleted"": false,
       ""participation_status"": ""needs_action"",
       ""transparency"": ""opaque"",
-      ""event_status"": ""confirmed"",
+      ""status"": ""confirmed"",
       ""categories"": [],
       ""attendees"": [
         {
@@ -589,7 +589,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
       ""deleted"": false,
       ""participation_status"": ""needs_action"",
       ""transparency"": ""opaque"",
-      ""event_status"": ""confirmed"",
+      ""status"": ""confirmed"",
       ""categories"": [],
       ""attendees"": [
         {
@@ -620,7 +620,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
                         Deleted = false,
                         ParticipationStatus = AttendeeStatus.NeedsAction,
                         Transparency = Transparency.Opaque,
-                        EventStatus = EventStatus.Confirmed,
+                        Status = EventStatus.Confirmed,
                         Categories = new string[] {},
                         Created = new DateTime(2014, 9, 1, 8, 0, 1, DateTimeKind.Utc),
                         Updated = new DateTime(2014, 9, 1, 9, 24, 16, DateTimeKind.Utc),
@@ -643,7 +643,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
                         Deleted = false,
                         ParticipationStatus = AttendeeStatus.NeedsAction,
                         Transparency = Transparency.Opaque,
-                        EventStatus = EventStatus.Confirmed,
+                        Status = EventStatus.Confirmed,
                         Categories = new string[] {},
                         Created = new DateTime(2014, 9, 1, 9, 0, 1, DateTimeKind.Utc),
                         Updated = new DateTime(2014, 9, 1, 10, 24, 16, DateTimeKind.Utc),
@@ -766,7 +766,7 @@ string.Format(@"{{
       ""recurring"": true,
       ""participation_status"": ""needs_action"",
       ""transparency"": ""opaque"",
-      ""event_status"": ""confirmed"",
+      ""status"": ""confirmed"",
       ""categories"": [],
       ""attendees"": [
         {{
@@ -803,7 +803,7 @@ string.Format(@"{{
                         Recurring = true,
                         ParticipationStatus = AttendeeStatus.NeedsAction,
                         Transparency = Transparency.Opaque,
-                        EventStatus = EventStatus.Confirmed,
+                        Status = EventStatus.Confirmed,
                         Categories = new string[] {},
                         Created = new DateTime(2014, 9, 1, 8, 0, 1, DateTimeKind.Utc),
                         Updated = new DateTime(2014, 9, 1, 9, 24, 16, DateTimeKind.Utc),
@@ -860,7 +860,7 @@ string.Format(@"{{
       ""deleted"": false,
       ""participation_status"": ""needs_action"",
       ""transparency"": ""opaque"",
-      ""event_status"": ""confirmed"",
+      ""status"": ""confirmed"",
       ""categories"": [],
       ""attendees"": [
         {
@@ -891,7 +891,7 @@ string.Format(@"{{
                 Deleted = false,
                 ParticipationStatus = AttendeeStatus.NeedsAction,
                 Transparency = Transparency.Opaque,
-                EventStatus = EventStatus.Confirmed,
+                Status = EventStatus.Confirmed,
                 Categories = new string[] {
 
                 },


### PR DESCRIPTION
Fixes:

- [Event.Status property is wrongly named Event.EventStatus](https://github.com/cronofy/cronofy-csharp/issues/63).