### PR TITLE
Bugfix in ReadEventsResponse, EventStatus JsonProperty

### DIFF
--- a/src/Cronofy/Responses/ReadEventsResponse.cs
+++ b/src/Cronofy/Responses/ReadEventsResponse.cs
@@ -170,7 +170,7 @@
             /// <value>
             /// The status of the event.
             /// </value>
-            [JsonProperty("event_status")]
+            [JsonProperty("status")]
             public string EventStatus { get; set; }
 
             /// <summary>


### PR DESCRIPTION
The EventStatus attribute was incorrect, it should just be status, so we never got the Event.Status correcly.