### PR TITLE
Clearer intellisense/description about specifying UTC start/end times for events

### DIFF
--- a/src/Cronofy/Requests/BaseEventRequest.cs
+++ b/src/Cronofy/Requests/BaseEventRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace Cronofy.Requests
+namespace Cronofy.Requests
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
@@ -27,7 +27,7 @@
         public string Description { get; set; }
 
         /// <summary>
-        /// Gets or sets the start time of the event.
+        /// Gets or sets the start time of the event. Represented as UTC regardless of timezone.
         /// </summary>
         /// <value>
         /// The start time of the event.
@@ -37,7 +37,7 @@
         public EventTime Start { get; set; }
 
         /// <summary>
-        /// Gets or sets the end time of the event.
+        /// Gets or sets the end time of the event. Represented as UTC regardless of timezone.
         /// </summary>
         /// <value>
         /// The end time of the event.
@@ -84,7 +84,7 @@
         public string Transparency { get; set; }
 
         /// <summary>
-        /// Gets or sets the timezone ID of the event.
+        /// Gets or sets the timezone ID of the event. Please note that start and end time must still be represented as UTC.
         /// </summary>
         /// <value>The time zone identifier.</value>
         [JsonProperty("tzid")]

--- a/src/Cronofy/UpsertEventRequestBuilder.cs
+++ b/src/Cronofy/UpsertEventRequestBuilder.cs
@@ -1,4 +1,4 @@
-﻿namespace Cronofy
+namespace Cronofy
 {
     using System;
     using System.Collections.Generic;
@@ -210,7 +210,7 @@
         }
 
         /// <summary>
-        /// Sets the start time of the event.
+        /// Sets the start time of the event. Represented as UTC regardless of timezone.
         /// </summary>
         /// <param name="start">
         /// The start time of the event.
@@ -226,7 +226,7 @@
         }
 
         /// <summary>
-        /// Sets the start time of the event.
+        /// Sets the start time of the event. Represented as UTC regardless of timezone.
         /// </summary>
         /// <param name="year">
         /// The year of the start time.
@@ -256,10 +256,10 @@
         }
 
         /// <summary>
-        /// Sets the start time of the event.
+        /// Sets the start time of the event. Represented as UTC regardless of timezone.
         /// </summary>
         /// <param name="start">
-        /// The start time of the event.
+        /// The start time of the event in UTC.
         /// </param>
         /// <returns>
         /// A reference to the modified builder.
@@ -272,7 +272,7 @@
         }
 
         /// <summary>
-        /// Sets the start time of the event.
+        /// Sets the start time of the event. Represented as UTC regardless of timezone
         /// </summary>
         /// <param name="year">
         /// The year of the start time.
@@ -296,7 +296,7 @@
         }
 
         /// <summary>
-        /// Sets the end time of the event.
+        /// Sets the end time of the event. Represented as UTC regardless of timezone
         /// </summary>
         /// <param name="end">
         /// The end time of the event.
@@ -312,7 +312,7 @@
         }
 
         /// <summary>
-        /// Sets the end time of the event.
+        /// Sets the end time of the event. Represented as UTC regardless of timezone
         /// </summary>
         /// <param name="year">
         /// The year of the end time.
@@ -342,7 +342,7 @@
         }
 
         /// <summary>
-        /// Sets the end time of the event.
+        /// Sets the end time of the event. Represented as UTC regardless of timezone
         /// </summary>
         /// <param name="end">
         /// The end time of the event.
@@ -358,7 +358,7 @@
         }
 
         /// <summary>
-        /// Sets the end time of the event.
+        /// Sets the end time of the event. Represented as UTC regardless of timezone.
         /// </summary>
         /// <param name="year">
         /// The year of the end time.
@@ -421,7 +421,7 @@
 
         /// <summary>
         /// Sets the time zone identifier for the start and end times of the
-        /// event.
+        /// event. Please note that start and end time must still be represented as UTC.
         /// </summary>
         /// <param name="timeZoneId">
         /// Time zone identifier, must not be empty.
@@ -502,7 +502,7 @@
         }
 
         /// <summary>
-        /// Sets the time zone identifier for the start time of the event.
+        /// Sets the time zone identifier for the start time of the event. Please note that start and end time must still be represented as UTC.
         /// </summary>
         /// <param name="timeZoneId">
         /// Time zone identifier, must not be empty.
@@ -523,7 +523,7 @@
         }
 
         /// <summary>
-        /// Sets the time zone identifier for the end time of the event.
+        /// Sets the time zone identifier for the end time of the event. Please note that start and end time must still be represented as UTC.
         /// </summary>
         /// <param name="timeZoneId">
         /// Time zone identifier, must not be empty.


### PR DESCRIPTION
Relates to issue 78: https://github.com/cronofy/cronofy-csharp/issues/78

I was confused about having to specify start/end for a new event in UTC, despite also specifying a timezone, so I decided to suggest an improvement to the Intellisense, which would hopefully make it more clear to people, what they are expected to supply. 