### PR TITLE
Add RTS status/disabling

### DIFF
--- a/src/Cronofy/Cronofy.csproj
+++ b/src/Cronofy/Cronofy.csproj
@@ -173,6 +173,9 @@
     <Compile Include="Requests\SmartInviteMultiRecipientRequest.cs" />
     <Compile Include="SmartInviteMultiRecipient.cs" />
     <Compile Include="Responses\SmartInviteMultiRecipientResponse.cs" />
+    <Compile Include="Requests\DisableRealTimeSchedulingRequest.cs" />
+    <Compile Include="Responses\RealTimeSchedulingStatusResponse.cs" />
+    <Compile Include="RealTimeSchedulingLinkStatus.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages/StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets" />

--- a/src/Cronofy/CronofyOAuthClient.cs
+++ b/src/Cronofy/CronofyOAuthClient.cs
@@ -250,6 +250,46 @@ namespace Cronofy
         }
 
         /// <inheritdoc/>
+        public RealTimeSchedulingLinkStatus DisableRealTimeSchedulingLink(string realTimeSchedulingId, string displayMessage)
+        {
+            Preconditions.NotBlank(nameof(realTimeSchedulingId), realTimeSchedulingId);
+            Preconditions.NotBlank(nameof(displayMessage), displayMessage);
+
+            var disableRealTimeSchedulingRequest = new DisableRealTimeSchedulingRequest
+            {
+                DisplayMessage = displayMessage
+            };
+
+            var request = new HttpRequest();
+
+            request.Method = "POST";
+            request.Url = string.Format(this.urlProvider.DisableRealTimeSchedulingUrlFormat, realTimeSchedulingId);
+            request.AddOAuthAuthorization(this.clientSecret);
+            request.SetJsonBody(disableRealTimeSchedulingRequest);
+
+            var response = this.HttpClient.GetJsonResponse<RealTimeSchedulingStatusResponse>(request);
+
+            return response.ToRealTimeSchedulingLinkStatus();
+        }
+
+        /// <inheritdoc/>
+        public RealTimeSchedulingLinkStatus GetRealTimeSchedulingLinkStatus(string linkToken)
+        {
+            Preconditions.NotBlank(nameof(linkToken), linkToken);
+
+            var request = new HttpRequest();
+
+            request.Method = "GET";
+            request.Url = string.Format(this.urlProvider.RealTimeSchedulingUrl);
+            request.QueryString.Add("token", linkToken);
+            request.AddOAuthAuthorization(this.clientSecret);
+
+            var response = this.HttpClient.GetJsonResponse<RealTimeSchedulingStatusResponse>(request);
+
+            return response.ToRealTimeSchedulingLinkStatus();
+        }
+
+        /// <inheritdoc/>
         public string RealTimeSequencing(RealTimeSequencingRequest realTimeSequencingRequest)
         {
             Preconditions.NotNull("realTimeSequencingRequest", realTimeSequencingRequest);

--- a/src/Cronofy/RealTimeSchedulingLinkStatus.cs
+++ b/src/Cronofy/RealTimeSchedulingLinkStatus.cs
@@ -1,0 +1,77 @@
+namespace Cronofy
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The status of a Real-Time Scheduling link.
+    /// </summary>
+    public class RealTimeSchedulingLinkStatus
+    {
+        /// <summary>
+        /// An enumeration of Real-Time Scheduling statuses.
+        /// </summary>
+        public enum LinkStatus
+        {
+            /// <summary>
+            /// A slot hasn't been chosen.
+            /// </summary>
+            Open,
+
+            /// <summary>
+            /// A slot has been chosen.
+            /// </summary>
+            Completed,
+
+            /// <summary>
+            /// The link has been disabled before a slot was chosen.
+            /// </summary>
+            Disabled
+        }
+
+        /// <summary>
+        /// Gets the Cronofy identifier for the Real-Time Scheduling link.
+        /// </summary>
+        /// <value>The Cronofy identifier for the Real-Time Scheduling link.</value>
+        public string RealTimeSchedulingId { get; internal set; }
+
+        /// <summary>
+        /// Gets the URL to direct the user to in order for them to select a time slot.
+        /// </summary>
+        /// <value>The URL to direct the user to in order for them to select a time slot.</value>
+        public string Url { get; internal set; }
+
+        /// <summary>
+        /// Gets the current state of the event associated with the link. Once completed the event will have start and end values.
+        /// </summary>
+        /// <value>The current state of the event associated with the link. Once completed the event will have start and end values.</value>
+        public Event Event { get; internal set; }
+
+        /// <summary>
+        /// Gets the current status of the link.
+        /// </summary>
+        /// <value>The current status of the link.</value>
+        public LinkStatus Status { get; internal set; }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return obj is RealTimeSchedulingLinkStatus status &&
+                   this.RealTimeSchedulingId == status.RealTimeSchedulingId &&
+                   this.Url == status.Url &&
+                   this.Event.Equals(status.Event) &&
+                   this.Status == status.Status;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            int hashCode = -549959893;
+            hashCode = (hashCode * -1521134295) + this.RealTimeSchedulingId.GetHashCode();
+            hashCode = (hashCode * -1521134295) + this.Url.GetHashCode();
+            hashCode = (hashCode * -1521134295) + this.Event.GetHashCode();
+            hashCode = (hashCode * -1521134295) + this.Status.GetHashCode();
+            return hashCode;
+        }
+    }
+}

--- a/src/Cronofy/RealTimeSchedulingRequestBuilder.cs
+++ b/src/Cronofy/RealTimeSchedulingRequestBuilder.cs
@@ -118,7 +118,7 @@
         /// The redirect uri for the request's oauth details, must not be blank.
         /// </param>
         /// <param name="scope">
-        /// The scope for the request's oauth details, must not be blank.
+        /// The scope for the request's oauth details.
         /// </param>
         /// <param name="state">
         /// The state for the request's oauth details.
@@ -127,12 +127,11 @@
         /// A reference to the <see cref="RealTimeSchedulingRequestBuilder"/>.
         /// </returns>
         /// <exception cref="ArgumentException">
-        /// Thrown if <paramref name="redirectUri"/> or <paramref name="scope"/> are empty.  
+        /// Thrown if <paramref name="redirectUri"/> is empty.  
         /// </exception>
         public RealTimeSchedulingRequestBuilder OAuthDetails(string redirectUri, string scope, string state)
         {
             Preconditions.NotBlank("redirectUri", redirectUri);
-            Preconditions.NotBlank("scope", scope);
 
             var oauthDetails = new RealTimeSchedulingRequest.OAuthDetails
             {

--- a/src/Cronofy/RealTimeSchedulingRequestBuilder.cs
+++ b/src/Cronofy/RealTimeSchedulingRequestBuilder.cs
@@ -40,6 +40,16 @@
         private string hourFormat;
 
         /// <summary>
+        /// The callback URL for the request.
+        /// </summary>
+        private string callbackUrl;
+
+        /// <summary>
+        /// The completed URL for the request.
+        /// </summary>
+        private string completedUrl;
+
+        /// <summary>
         /// Sets the OAuth details of the request.
         /// </summary>
         /// <param name="redirectUri">
@@ -276,6 +286,48 @@
             return this;
         }
 
+        /// <summary>
+        /// Sets the callback URL for the request.
+        /// </summary>
+        /// <param name="callbackUrl">
+        /// The callback URL to use for the request, must not be blank.
+        /// </param>
+        /// <returns>
+        /// A reference to the <see cref="RealTimeSchedulingRequestBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="callbackUrl"/> is empty. 
+        /// </exception>
+        public RealTimeSchedulingRequestBuilder CallbackUrl(string callbackUrl)
+        {
+            Preconditions.NotBlank(nameof(callbackUrl), callbackUrl);
+
+            this.callbackUrl = callbackUrl;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the redirect URLs for the request.
+        /// </summary>
+        /// <param name="completedUrl">
+        /// The completed URL to use for the request, must not be blank.
+        /// </param>
+        /// <returns>
+        /// A reference to the <see cref="RealTimeSchedulingRequestBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="completedUrl"/> is empty. 
+        /// </exception>
+        public RealTimeSchedulingRequestBuilder RedirectUrls(string completedUrl)
+        {
+            Preconditions.NotBlank(nameof(completedUrl), completedUrl);
+
+            this.completedUrl = completedUrl;
+
+            return this;
+        }
+
         /// <inheritdoc />
         public RealTimeSchedulingRequest Build()
         {
@@ -285,7 +337,16 @@
                 Event = this.upsertEventRequestBuilder.Build(),
                 TargetCalendars = this.targetCalendars,
                 Tzid = this.tzid,
+                CallbackUrl = this.callbackUrl,
             };
+
+            if (this.completedUrl != null)
+            {
+                request.RedirectUrls = new RealTimeSchedulingRequest.RedirectUrlsInfo
+                {
+                    CompletedUrl = this.completedUrl,
+                };
+            }
 
             if (this.availabilityRequestBuilder != null)
             {

--- a/src/Cronofy/RealTimeSequencingRequestBuilder.cs
+++ b/src/Cronofy/RealTimeSequencingRequestBuilder.cs
@@ -113,7 +113,7 @@
         /// The redirect uri for the request's oauth details, must not be blank.
         /// </param>
         /// <param name="scope">
-        /// The scope for the request's oauth details, must not be blank.
+        /// The scope for the request's oauth details.
         /// </param>
         /// <param name="state">
         /// The state for the request's oauth details.
@@ -122,12 +122,11 @@
         /// A reference to the <see cref="RealTimeSequencingRequestBuilder"/>.
         /// </returns>
         /// <exception cref="ArgumentException">
-        /// Thrown if <paramref name="redirectUri"/> or <paramref name="scope"/> are empty.  
+        /// Thrown if <paramref name="redirectUri"/> is empty.  
         /// </exception>
         public RealTimeSequencingRequestBuilder OAuthDetails(string redirectUri, string scope, string state)
         {
             Preconditions.NotBlank("redirectUri", redirectUri);
-            Preconditions.NotBlank("scope", scope);
 
             var oauthDetails = new RealTimeSchedulingRequest.OAuthDetails
             {

--- a/src/Cronofy/RealTimeSequencingRequestBuilder.cs
+++ b/src/Cronofy/RealTimeSequencingRequestBuilder.cs
@@ -40,6 +40,11 @@
         private string hourFormat;
 
         /// <summary>
+        /// The callback URL for the request.
+        /// </summary>
+        private string callbackUrl;
+
+        /// <summary>
         /// Sets the OAuth details of the request.
         /// </summary>
         /// <param name="redirectUri">
@@ -276,6 +281,27 @@
             return this;
         }
 
+        /// <summary>
+        /// Sets the callback URL for the request.
+        /// </summary>
+        /// <param name="callbackUrl">
+        /// The callback URL to use for the request, must not be blank.
+        /// </param>
+        /// <returns>
+        /// A reference to the <see cref="RealTimeSequencingRequestBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="callbackUrl"/> is empty. 
+        /// </exception>
+        public RealTimeSequencingRequestBuilder CallbackUrl(string callbackUrl)
+        {
+            Preconditions.NotBlank(nameof(callbackUrl), callbackUrl);
+
+            this.callbackUrl = callbackUrl;
+
+            return this;
+        }
+
         /// <inheritdoc />
         public RealTimeSequencingRequest Build()
         {
@@ -285,6 +311,7 @@
                 Event = this.upsertEventRequestBuilder.Build(),
                 TargetCalendars = this.targetCalendars,
                 Tzid = this.tzid,
+                CallbackUrl = this.callbackUrl,
             };
 
             if (this.availabilityRequestBuilder != null)

--- a/src/Cronofy/Requests/DisableRealTimeSchedulingRequest.cs
+++ b/src/Cronofy/Requests/DisableRealTimeSchedulingRequest.cs
@@ -1,0 +1,11 @@
+namespace Cronofy.Requests
+{
+    using System;
+    using Newtonsoft.Json;
+
+    internal class DisableRealTimeSchedulingRequest
+    {
+        [JsonProperty("display_message")]
+        public string DisplayMessage { get; set; }
+    }
+}

--- a/src/Cronofy/Requests/RealTimeSchedulingBaseRequest.cs
+++ b/src/Cronofy/Requests/RealTimeSchedulingBaseRequest.cs
@@ -73,6 +73,13 @@ namespace Cronofy.Requests
         public string Tzid { get; set; }
 
         /// <summary>
+        /// Gets or sets the callback URL for the request.
+        /// </summary>
+        /// <value>The callback URL for the request.</value>
+        [JsonProperty("callback_url")]
+        public string CallbackUrl { get; set; }
+
+        /// <summary>
         /// Class for the serialization of the oauth details.
         /// </summary>
         public sealed class OAuthDetails

--- a/src/Cronofy/Requests/RealTimeSchedulingRequest.cs
+++ b/src/Cronofy/Requests/RealTimeSchedulingRequest.cs
@@ -15,5 +15,29 @@
         /// </value>
         [JsonProperty("availability")]
         public AvailabilityRequest Availability { get; set; }
+
+        /// <summary>
+        /// Gets or sets the redirect URLs for the request.
+        /// </summary>
+        /// <value>
+        /// The redirect URLs for the request.
+        /// </value>
+        [JsonProperty("redirect_urls")]
+        public RedirectUrlsInfo RedirectUrls { get; set; }
+
+        /// <summary>
+        /// Class for serialization of real-time scheduling redirect URLs.
+        /// </summary>
+        public class RedirectUrlsInfo
+        {
+            /// <summary>
+            /// Gets or sets the Completed URL for the request.
+            /// </summary>
+            /// <value>
+            /// The Completed URL for the request.
+            /// </value>
+            [JsonProperty("completed_url")]
+            public string CompletedUrl { get; set; }
+        }
     }
 }

--- a/src/Cronofy/Responses/RealTimeSchedulingStatusResponse.cs
+++ b/src/Cronofy/Responses/RealTimeSchedulingStatusResponse.cs
@@ -1,0 +1,37 @@
+namespace Cronofy.Responses
+{
+    using System;
+    using Newtonsoft.Json;
+
+    internal class RealTimeSchedulingStatusResponse
+    {
+        [JsonProperty("real_time_scheduling")]
+        public RealTimeSequencingStatusResponseContent RealTimeScheduling { get; set; }
+
+        public RealTimeSchedulingLinkStatus ToRealTimeSchedulingLinkStatus()
+        {
+            return new RealTimeSchedulingLinkStatus
+            {
+                RealTimeSchedulingId = this.RealTimeScheduling.RealTimeSchedulingId,
+                Url = this.RealTimeScheduling.Url,
+                Status = (RealTimeSchedulingLinkStatus.LinkStatus)Enum.Parse(typeof(RealTimeSchedulingLinkStatus.LinkStatus), this.RealTimeScheduling.Status, true),
+                Event = this.RealTimeScheduling.Event.ToEvent(),
+            };
+        }
+
+        internal class RealTimeSequencingStatusResponseContent
+        {
+            [JsonProperty("real_time_scheduling_id")]
+            public string RealTimeSchedulingId { get; set; }
+
+            [JsonProperty("url")]
+            public string Url { get; set; }
+
+            [JsonProperty("status")]
+            public string Status { get; set; }
+
+            [JsonProperty("event")]
+            public ReadEventsResponse.EventResponse Event { get; set; }
+        }
+    }
+}

--- a/src/Cronofy/Settings.StyleCop
+++ b/src/Cronofy/Settings.StyleCop
@@ -4,6 +4,10 @@
   </GlobalSettings>
   <Analyzers>
     <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
+      <AnalyzerSettings>
+        <BooleanProperty Name="IgnorePrivates">True</BooleanProperty>
+        <BooleanProperty Name="IgnoreInternals">True</BooleanProperty>
+      </AnalyzerSettings>
       <Rules>
         <Rule Name="PropertyDocumentationMustHaveValue">
           <RuleSettings>

--- a/src/Cronofy/UrlProvider.cs
+++ b/src/Cronofy/UrlProvider.cs
@@ -106,6 +106,11 @@ namespace Cronofy
         private const string RealTimeSchedulingUrlFormat = "https://api{0}.cronofy.com/v1/real_time_scheduling";
 
         /// <summary>
+        /// The URL format for the real time scheduling disable endpoint.
+        /// </summary>
+        private const string DisableRealTimeSchedulingUrlFormatFormat = "https://api{0}.cronofy.com/v1/real_time_scheduling/{{0}}/disable";
+
+        /// <summary>
         /// The URL of the link tokens endpoint.
         /// </summary>
         private const string LinkTokensUrlFormat = "https://api{0}.cronofy.com/v1/link_tokens";
@@ -185,6 +190,7 @@ namespace Cronofy
             this.AvailabilityUrl = string.Format(AvailabilityUrlFormat, suffix);
             this.AddToCalendarUrl = string.Format(AddToCalendarUrlFormat, suffix);
             this.RealTimeSchedulingUrl = string.Format(RealTimeSchedulingUrlFormat, suffix);
+            this.DisableRealTimeSchedulingUrlFormat = string.Format(DisableRealTimeSchedulingUrlFormatFormat, suffix);
             this.LinkTokensUrl = string.Format(LinkTokensUrlFormat, suffix);
             this.SmartInviteUrl = string.Format(SmartInviteUrlFormat, suffix);
             this.RevokeProfileAuthorizationUrlFormat = string.Format(RevokeProfileAuthorizationUrlFormatFormat, suffix);
@@ -431,6 +437,18 @@ namespace Cronofy
         /// The real time scheduling URL.
         /// </value>
         public string RealTimeSchedulingUrl
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Gets the real time scheduling disable URL format.
+        /// </summary>
+        /// <value>
+        /// The real time scheduling disable URL format.
+        /// </value>
+        public string DisableRealTimeSchedulingUrlFormat
         {
             get;
             private set;

--- a/test/Cronofy.Test/Cronofy.Test.csproj
+++ b/test/Cronofy.Test/Cronofy.Test.csproj
@@ -91,6 +91,7 @@
     <Compile Include="CronofyOAuthClientTests\RealTimeSequencing.cs" />
     <Compile Include="CronofyOAuthClientTests\SubmitApplicationVerification.cs" />
     <Compile Include="CronofyAdminApiClientTests\ProvisionApplication.cs" />
+    <Compile Include="CronofyOAuthClientTests\DisableRealTimeSchedulingLink.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/test/Cronofy.Test/Cronofy.Test.csproj
+++ b/test/Cronofy.Test/Cronofy.Test.csproj
@@ -92,6 +92,7 @@
     <Compile Include="CronofyOAuthClientTests\SubmitApplicationVerification.cs" />
     <Compile Include="CronofyAdminApiClientTests\ProvisionApplication.cs" />
     <Compile Include="CronofyOAuthClientTests\DisableRealTimeSchedulingLink.cs" />
+    <Compile Include="CronofyOAuthClientTests\GetRealTimeSchedulingLinkStatus.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/test/Cronofy.Test/CronofyOAuthClientTests/DisableRealTimeSchedulingLink.cs
+++ b/test/Cronofy.Test/CronofyOAuthClientTests/DisableRealTimeSchedulingLink.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using NUnit.Framework;
+using Cronofy.Requests;
+
+namespace Cronofy.Test.CronofyOAuthClientTests
+{
+    [TestFixture]
+    public sealed class DisableRealTimeSchedulingLink
+    {
+        private const string clientId = "abcdef123456";
+        private const string clientSecret = "s3cr3t1v3";
+
+        private CronofyOAuthClient client;
+        private StubHttpClient http;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.client = new CronofyOAuthClient(clientId, clientSecret);
+            this.http = new StubHttpClient();
+
+            client.HttpClient = http;
+        }
+
+        [Test]
+        public void CanDisableAnRTSLink()
+        {
+            var rtsId = "sch_123";
+            var rtsUrl = "https://app.cronofy.com/add_to_calendar/scheduling/rtsToken";
+            var displayMessage = "disabled";
+
+            http.Stub(HttpPost
+                .Url("https://api.cronofy.com/v1/real_time_scheduling/sch_123/disable")
+                .RequestHeader("Authorization", string.Format("Bearer {0}", clientSecret))
+                .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                .RequestBodyFormat(
+                    @"{{""display_message"":""{0}""}}", displayMessage)
+                .ResponseCode(200)
+                .ResponseBodyFormat(
+                    @"{{""real_time_scheduling"":{{""real_time_scheduling_id"":""{0}"",""url"":""{1}"",""status"":""disabled"",""event"":{{""summary"":""event summary"",""event_id"":""event id"",""event_private"":false}}}}}}", rtsId, rtsUrl)
+            );
+
+            var response = client.DisableRealTimeSchedulingLink(rtsId, displayMessage);
+            var expectedResponse = new RealTimeSchedulingLinkStatus
+            {
+                RealTimeSchedulingId = rtsId,
+                Status = RealTimeSchedulingLinkStatus.LinkStatus.Disabled,
+                Url = rtsUrl,
+                Event = new Event
+                {
+                    Summary = "event summary",
+                    EventId = "event id",
+                    EventPrivate = false,
+                }
+            };
+
+            Assert.AreEqual(response, expectedResponse);
+        }
+    }
+}

--- a/test/Cronofy.Test/CronofyOAuthClientTests/GetRealTimeSchedulingLinkStatus.cs
+++ b/test/Cronofy.Test/CronofyOAuthClientTests/GetRealTimeSchedulingLinkStatus.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using NUnit.Framework;
+using Cronofy.Requests;
+
+namespace Cronofy.Test.CronofyOAuthClientTests
+{
+    [TestFixture]
+    public sealed class GetRealTimeSchedulingLinkStatus
+    {
+        private const string clientId = "abcdef123456";
+        private const string clientSecret = "s3cr3t1v3";
+
+        private CronofyOAuthClient client;
+        private StubHttpClient http;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.client = new CronofyOAuthClient(clientId, clientSecret);
+            this.http = new StubHttpClient();
+
+            client.HttpClient = http;
+        }
+
+        [Test]
+        public void CanGetRTSLinkStatus()
+        {
+            var rtsToken = "rtsToken";
+            var rtsUrl = string.Format("https://app.cronofy.com/add_to_calendar/scheduling/{0}", rtsToken);
+
+            http.Stub(HttpGet
+                .Url(string.Format("https://api.cronofy.com/v1/real_time_scheduling?token={0}", rtsToken))
+                .RequestHeader("Authorization", string.Format("Bearer {0}", clientSecret))
+                .ResponseCode(200)
+                .ResponseBodyFormat(
+                    @"{{""real_time_scheduling"":{{""real_time_scheduling_id"":""sch_123"",""url"":""{0}"",""status"":""open"",""event"":{{""summary"":""event summary"",""event_id"":""event id"",""event_private"":false}}}}}}", rtsUrl)
+            );
+
+            var response = client.GetRealTimeSchedulingLinkStatus(rtsToken);
+            var expectedResponse = new RealTimeSchedulingLinkStatus
+            {
+                RealTimeSchedulingId = "sch_123",
+                Status = RealTimeSchedulingLinkStatus.LinkStatus.Open,
+                Url = rtsUrl,
+                Event = new Event
+                {
+                    Summary = "event summary",
+                    EventId = "event id",
+                    EventPrivate = false,
+                }
+            };
+
+            Assert.AreEqual(response, expectedResponse);
+        }
+    }
+}

--- a/test/Cronofy.Test/CronofyOAuthClientTests/RealTimeScheduling.cs
+++ b/test/Cronofy.Test/CronofyOAuthClientTests/RealTimeScheduling.cs
@@ -50,7 +50,7 @@ namespace Cronofy.Test.CronofyOAuthClientTests
         }
 
         [Test]
-        public void CanGetOAuthUrlWithAvailabilityTargetCalendarsAndHourFormat()
+        public void CanGetRTSUrlWithAvailabilityTargetCalendarsAndHourFormat()
         {
             var expectedUrl = "http://test.com";
             var hourFormat = "H";
@@ -107,6 +107,79 @@ namespace Cronofy.Test.CronofyOAuthClientTests
                 .AvailabilityRequest(availabilityRequest)
                 .AddTargetCalendar(sub, calendarId)
                 .HourFormat("H")
+                .Build();
+
+            var actualUrl = client.RealTimeScheduling(request);
+
+            Assert.AreEqual(expectedUrl, actualUrl);
+        }
+
+        [Test]
+        public void CanGetRTSUrlWithCallbackUrlAndCompletedUrl()
+        {
+            var expectedUrl = "http://test.com";
+            var hourFormat = "H";
+            var callbackUrl = "https://test.com/callback_url";
+            var completedUrl = "https://test.com/completed_url";
+
+            http.Stub(
+                HttpPost
+                    .Url("https://api.cronofy.com/v1/real_time_scheduling")
+                    .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                    .RequestBodyFormat(
+                        "{{" +
+                            "\"availability\":{{" +
+                                "\"participants\":[{{" +
+                                    "\"members\":[{{" +
+                                        "\"sub\":\"{6}\"" +
+                                    "}}]" +
+                                "}}]," +
+                                "\"required_duration\":{{" +
+                                    "\"minutes\":60" +
+                                "}}," +
+                                "\"available_periods\":[{{" +
+                                    "\"start\":\"{7}\"," +
+                                    "\"end\":\"{8}\"" +
+                                "}}]" +
+                            "}}," +
+                            "\"redirect_urls\":{{" +
+                                "\"completed_url\":\"{13}\"" +
+                            "}}," +
+                            "\"client_id\":\"{0}\"," +
+                            "\"client_secret\":\"{1}\"," +
+                            "\"oauth\":{{" +
+                                "\"redirect_uri\":\"{2}\"," +
+                                "\"scope\":\"{3}\"" +
+                            "}}," +
+                            "\"event\":{{" +
+                                "\"event_id\":\"{4}\"," +
+                                "\"summary\":\"{5}\"" +
+                            "}}," +
+                            "\"target_calendars\":[{{" +
+                                "\"sub\":\"{9}\"," +
+                                "\"calendar_id\":\"{10}\"" +
+                            "}}]," +
+                            "\"formatting\":{{" +
+                                "\"hour_format\":\"{11}\"" +
+                            "}}," +
+                            "\"tzid\":\"Etc/UTC\"," +
+                            "\"callback_url\":\"{12}\"" +
+                        "}}",
+                        clientId, clientSecret, redirectUrl, scope, eventId, summary, sub, startString, endString, sub, calendarId, hourFormat, callbackUrl, completedUrl)
+                    .ResponseCode(200)
+                    .ResponseBodyFormat(
+                        "{{\"url\":\"{0}\"}}", expectedUrl)
+            );
+
+            var request = new RealTimeSchedulingRequestBuilder()
+                .OAuthDetails(redirectUrl, scope)
+                .Timezone("Etc/UTC")
+                .UpsertEventRequest(upsertEventRequestWithoutStartAndEnd)
+                .AvailabilityRequest(availabilityRequest)
+                .AddTargetCalendar(sub, calendarId)
+                .HourFormat("H")
+                .CallbackUrl(callbackUrl)
+                .RedirectUrls(completedUrl)
                 .Build();
 
             var actualUrl = client.RealTimeScheduling(request);

--- a/test/Cronofy.Test/CronofyOAuthClientTests/RealTimeSequencing.cs
+++ b/test/Cronofy.Test/CronofyOAuthClientTests/RealTimeSequencing.cs
@@ -96,7 +96,8 @@ namespace Cronofy.Test.CronofyOAuthClientTests
                       ""formatting"":{
                         ""hour_format"":""H""
                       },
-                      ""tzid"":""Etc/UTC""
+                      ""tzid"":""Etc/UTC"",
+                      ""callback_url"":""http://example.com/callback""
                     }")
                     .ResponseCode(200)
                     .ResponseBodyFormat("{{\"url\":\"{0}\"}}", expectedUrl)
@@ -109,6 +110,7 @@ namespace Cronofy.Test.CronofyOAuthClientTests
                 .SequencedAvailabilityRequest(availabilityRequest)
                 .AddTargetCalendar("sub", "calendarId")
                 .HourFormat("H")
+                .CallbackUrl("http://example.com/callback")
                 .Build();
 
             var actualUrl = client.RealTimeSequencing(request);


### PR DESCRIPTION
Adds support for
- https://docs.cronofy.com/developers/api/scheduling/real-time-scheduling/status/
- https://docs.cronofy.com/developers/api/scheduling/real-time-scheduling/disable/

Adds support for the `callback_url` and `redirect_urls.completed_url` parameters when creating a request.
Makes the `scope` part of the Oauth parameters optional, matching the reality of the API.