### PR TITLE
Conferencing support - events

### DIFF
--- a/src/Cronofy/Requests/UpsertEventRequest.cs
+++ b/src/Cronofy/Requests/UpsertEventRequest.cs
@@ -65,6 +65,15 @@
         public RequestConferencing Conferencing { get; set; }
 
         /// <summary>
+        /// Gets or sets the subscriptions for the event.
+        /// </summary>
+        /// <value>
+        /// The subscriptions for the event.
+        /// </value>
+        [JsonProperty("subscriptions")]
+        public IEnumerable<RequestSubscription> Subscriptions { get; set; }
+
+        /// <summary>
         /// Class for the serialization of the attendees for an upsert event
         /// request.
         /// </summary>
@@ -147,6 +156,54 @@
             /// </value>
             [JsonProperty("join_url")]
             public string JoinUrl { get; set; }
+        }
+
+        /// <summary>
+        /// Class for the serialization of event subscriptions.
+        /// </summary>
+        public sealed class RequestSubscription
+        {
+            /// <summary>
+            /// Gets or sets the type of the subscription.
+            /// </summary>
+            /// <value>
+            /// The type of the subscription.
+            /// </value>
+            [JsonProperty("type")]
+            public string Type { get; set; }
+
+            /// <summary>
+            /// Gets or sets the destination URI Cronofy will call when the subscription is triggered.
+            /// </summary>
+            /// <value>
+            /// The destination URI Cronofy will call when the subscription is triggered.
+            /// </value>
+            [JsonProperty("uri")]
+            public string Uri { get; set; }
+
+            /// <summary>
+            /// Gets or sets the interactions subscribed to.
+            /// </summary>
+            /// <value>
+            /// The interactions subscribed to.
+            /// </value>
+            [JsonProperty("interactions")]
+            public IEnumerable<Interaction> Interactions { get; set; }
+
+            /// <summary>
+            /// Class for the serialization of event subscription interactions.
+            /// </summary>
+            public sealed class Interaction
+            {
+                /// <summary>
+                /// Gets or sets the type of the interaction.
+                /// </summary>
+                /// <value>
+                /// The type of the interaction.
+                /// </value>
+                [JsonProperty("type")]
+                public string Type { get; set; }
+            }
         }
     }
 }

--- a/src/Cronofy/Requests/UpsertEventRequest.cs
+++ b/src/Cronofy/Requests/UpsertEventRequest.cs
@@ -56,6 +56,15 @@
         public bool? EventPrivate { get; set; }
 
         /// <summary>
+        /// Gets or sets the conferencing configuration for the event.
+        /// </summary>
+        /// <value>
+        /// The conferencing configuration for the event.
+        /// </value>
+        [JsonProperty("conferencing")]
+        public RequestConferencing Conferencing { get; set; }
+
+        /// <summary>
         /// Class for the serialization of the attendees for an upsert event
         /// request.
         /// </summary>
@@ -103,6 +112,41 @@
             /// </value>
             [JsonProperty("display_name")]
             public string DisplayName { get; set; }
+        }
+
+        /// <summary>
+        /// Class for the serialization of event conferencing.
+        /// </summary>
+        public sealed class RequestConferencing
+        {
+            /// <summary>
+            /// Gets or sets the conferencing profile ID.
+            /// </summary>
+            /// <value>
+            /// The conferencing profile ID.
+            /// </value>
+            [JsonProperty("profile_id")]
+            public string ProfileId { get; set; }
+
+            /// <summary>
+            /// Gets or sets the conferencing provider's user-facing name.
+            /// Only valid when using a <see cref="ProfileId"/> equal to <c>"explicit"</c>.
+            /// </summary>
+            /// <value>
+            /// The conferencing provider's user-facing name.
+            /// </value>
+            [JsonProperty("provider_description")]
+            public string ProviderDescription { get; set; }
+
+            /// <summary>
+            /// Gets or sets the conferencing join URL.
+            /// Only valid when using a <see cref="ProfileId"/> equal to <c>"explicit"</c>.
+            /// </summary>
+            /// <value>
+            /// The conferencing join URL.
+            /// </value>
+            [JsonProperty("join_url")]
+            public string JoinUrl { get; set; }
         }
     }
 }

--- a/src/Cronofy/UpsertEventRequestBuilder.cs
+++ b/src/Cronofy/UpsertEventRequestBuilder.cs
@@ -128,6 +128,11 @@
         private UpsertEventRequest.RequestConferencing conferencing;
 
         /// <summary>
+        /// The subscriptions for the event.
+        /// </summary>
+        private ICollection<UpsertEventRequest.RequestSubscription> subscriptions;
+
+        /// <summary>
         /// Initializes a new instance of the
         /// <see cref="Cronofy.UpsertEventRequestBuilder"/> class.
         /// </summary>
@@ -699,6 +704,57 @@
             return this;
         }
 
+        /// <summary>
+        /// Adds a webhook subscription to an interaction to the event.
+        /// </summary>
+        /// <returns>
+        /// A reference to the modified builder.
+        /// </returns>
+        /// <param name="uri">The destination URI Cronofy will call when the subscription is triggered.</param>
+        /// <param name="type">The type of interaction to subscribe to.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="uri"/> or <paramref name="type"/> are empty.
+        /// </exception>
+        public UpsertEventRequestBuilder InteractionSubscription(string uri, string type)
+        {
+            Preconditions.NotEmpty(nameof(uri), uri);
+            Preconditions.NotEmpty(nameof(type), type);
+
+            if (this.subscriptions == null)
+            {
+                this.subscriptions = new List<UpsertEventRequest.RequestSubscription>();
+            }
+
+            this.subscriptions.Add(new UpsertEventRequest.RequestSubscription
+            {
+                Type = "webhook",
+                Uri = uri,
+                Interactions = new[]
+                {
+                    new UpsertEventRequest.RequestSubscription.Interaction
+                    {
+                        Type = type,
+                    },
+                },
+            });
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the subscriptions for the event.
+        /// </summary>
+        /// <returns>
+        /// A reference to the modified builder.
+        /// </returns>
+        /// <param name="subscriptions">The event subscriptions.</param>
+        public UpsertEventRequestBuilder Subscriptions(ICollection<UpsertEventRequest.RequestSubscription> subscriptions)
+        {
+            this.subscriptions = subscriptions;
+
+            return this;
+        }
+
         /// <inheritdoc/>
         public UpsertEventRequest Build()
         {
@@ -717,6 +773,7 @@
                 RemindersCreateOnly = this.remindersCreateOnly,
                 EventPrivate = this.eventPrivate,
                 Conferencing = this.conferencing,
+                Subscriptions = this.subscriptions,
             };
 
             if (string.IsNullOrEmpty(this.locationDescription) == false

--- a/src/Cronofy/UpsertEventRequestBuilder.cs
+++ b/src/Cronofy/UpsertEventRequestBuilder.cs
@@ -123,6 +123,11 @@
         private ICollection<UpsertEventRequest.RequestAttendee> addedAttendees;
 
         /// <summary>
+        /// The conferencing for the event.
+        /// </summary>
+        private UpsertEventRequest.RequestConferencing conferencing;
+
+        /// <summary>
         /// Initializes a new instance of the
         /// <see cref="Cronofy.UpsertEventRequestBuilder"/> class.
         /// </summary>
@@ -648,6 +653,52 @@
             return this;
         }
 
+        /// <summary>
+        /// Adds conferencing to the event.
+        /// </summary>
+        /// <returns>
+        /// A reference to the modified builder.
+        /// </returns>
+        /// <param name="profileId">The profile ID of the required conferencing. Either an explicit ID, or one of our documented built-in values.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="profileId"/> is empty.
+        /// </exception>
+        public UpsertEventRequestBuilder Conferencing(string profileId)
+        {
+            Preconditions.NotEmpty(nameof(profileId), profileId);
+
+            this.conferencing = new UpsertEventRequest.RequestConferencing
+            {
+                ProfileId = profileId,
+            };
+            return this;
+        }
+
+        /// <summary>
+        /// Adds explicit (not provisioned by Cronofy) conferencing to the event.
+        /// </summary>
+        /// <returns>
+        /// A reference to the modified builder.
+        /// </returns>
+        /// <param name="providerDescription">The user-facing provider name of the conferencing.</param>
+        /// <param name="joinUrl">The URL to join the conferencing meeting.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="providerDescription"/> or <paramref name="joinUrl"/> are empty.
+        /// </exception>
+        public UpsertEventRequestBuilder ExplicitConferencing(string providerDescription, string joinUrl)
+        {
+            Preconditions.NotEmpty(nameof(providerDescription), providerDescription);
+            Preconditions.NotEmpty(nameof(joinUrl), joinUrl);
+
+            this.conferencing = new UpsertEventRequest.RequestConferencing
+            {
+                ProfileId = "explicit",
+                ProviderDescription = providerDescription,
+                JoinUrl = joinUrl,
+            };
+            return this;
+        }
+
         /// <inheritdoc/>
         public UpsertEventRequest Build()
         {
@@ -665,6 +716,7 @@
                 Color = this.color,
                 RemindersCreateOnly = this.remindersCreateOnly,
                 EventPrivate = this.eventPrivate,
+                Conferencing = this.conferencing,
             };
 
             if (string.IsNullOrEmpty(this.locationDescription) == false

--- a/test/Cronofy.Test/CronofyAccountClientTests/UpsertEvent.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/UpsertEvent.cs
@@ -776,5 +776,89 @@ namespace Cronofy.Test.CronofyAccountClientTests
 
             this.Client.UpsertEvent(CalendarId, builder);
         }
+
+        [Test]
+        public void CanUpsertInteractionSubscription()
+        {
+            const string eventId = "qTtZdczOccgaPncGJaCiLg";
+            const string summary = "Board meeting";
+            const string description = "Discuss plans for the next quarter";
+            const string startTimeString = "2014-08-05";
+            const string endTimeString = "2014-08-06";
+            const string interactionType = "conferencing_assigned";
+            const string subscriptionUri = "https://consumer.com/webhook?state=foo";
+
+            this.Http.Stub(
+                HttpPost
+                .Url("https://api.cronofy.com/v1/calendars/" + CalendarId + "/events")
+                .RequestHeader("Authorization", "Bearer " + AccessToken)
+                .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                .RequestBodyFormat(
+                    "{{\"event_id\":\"{0}\"," +
+                    "\"subscriptions\":[{{\"type\":\"webhook\",\"uri\":\"{5}\",\"interactions\":[{{\"type\":\"{6}\"}}]}}]," +
+                    "\"summary\":\"{1}\"," +
+                    "\"description\":\"{2}\"," +
+                    "\"start\":{{\"time\":\"{3}\",\"tzid\":\"Etc/UTC\"}}," +
+                    "\"end\":{{\"time\":\"{4}\",\"tzid\":\"Etc/UTC\"}}" +
+                    "}}",
+                    eventId,
+                    summary,
+                    description,
+                    startTimeString,
+                    endTimeString,
+                    subscriptionUri,
+                    interactionType)
+                .ResponseCode(202));
+
+            var builder = new UpsertEventRequestBuilder()
+                .EventId(eventId)
+                .Summary(summary)
+                .Description(description)
+                .Start(new Date(2014, 8, 5))
+                .End(new Date(2014, 8, 6))
+                .InteractionSubscription(subscriptionUri, interactionType);
+
+            this.Client.UpsertEvent(CalendarId, builder);
+        }
+
+        [Test]
+        public void CanUpsertRemovingSubscriptions()
+        {
+            const string eventId = "qTtZdczOccgaPncGJaCiLg";
+            const string summary = "Board meeting";
+            const string description = "Discuss plans for the next quarter";
+            const string startTimeString = "2014-08-05";
+            const string endTimeString = "2014-08-06";
+
+            this.Http.Stub(
+                HttpPost
+                .Url("https://api.cronofy.com/v1/calendars/" + CalendarId + "/events")
+                .RequestHeader("Authorization", "Bearer " + AccessToken)
+                .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                .RequestBodyFormat(
+                    "{{\"event_id\":\"{0}\"," +
+                    "\"subscriptions\":[]," +
+                    "\"summary\":\"{1}\"," +
+                    "\"description\":\"{2}\"," +
+                    "\"start\":{{\"time\":\"{3}\",\"tzid\":\"Etc/UTC\"}}," +
+                    "\"end\":{{\"time\":\"{4}\",\"tzid\":\"Etc/UTC\"}}" +
+                    "}}",
+                    eventId,
+                    summary,
+                    description,
+                    startTimeString,
+                    endTimeString)
+                .ResponseCode(202));
+
+            var builder = new UpsertEventRequestBuilder()
+                .EventId(eventId)
+                .Summary(summary)
+                .Description(description)
+                .Start(new Date(2014, 8, 5))
+                .End(new Date(2014, 8, 6))
+                .Subscriptions(new Requests.UpsertEventRequest.RequestSubscription[0]);
+
+            this.Client.UpsertEvent(CalendarId, builder);
+        }
     }
 }

--- a/test/Cronofy.Test/CronofyAccountClientTests/UpsertEvent.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/UpsertEvent.cs
@@ -690,5 +690,91 @@ namespace Cronofy.Test.CronofyAccountClientTests
 
             this.Client.UpsertEvent(CalendarId, builder);
         }
+
+        [Test]
+        public void CanUpsertConferencing()
+        {
+            const string eventId = "qTtZdczOccgaPncGJaCiLg";
+            const string summary = "Board meeting";
+            const string description = "Discuss plans for the next quarter";
+            const string startTimeString = "2014-08-05";
+            const string endTimeString = "2014-08-06";
+            const string conferencingProfileId = "integrated";
+
+            this.Http.Stub(
+                HttpPost
+                .Url("https://api.cronofy.com/v1/calendars/" + CalendarId + "/events")
+                .RequestHeader("Authorization", "Bearer " + AccessToken)
+                .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                .RequestBodyFormat(
+                    "{{\"event_id\":\"{0}\"," +
+                    "\"conferencing\":{{\"profile_id\":\"{5}\"}}," +
+                    "\"summary\":\"{1}\"," +
+                    "\"description\":\"{2}\"," +
+                    "\"start\":{{\"time\":\"{3}\",\"tzid\":\"Etc/UTC\"}}," +
+                    "\"end\":{{\"time\":\"{4}\",\"tzid\":\"Etc/UTC\"}}" +
+                    "}}",
+                    eventId,
+                    summary,
+                    description,
+                    startTimeString,
+                    endTimeString,
+                    conferencingProfileId)
+                .ResponseCode(202));
+
+            var builder = new UpsertEventRequestBuilder()
+                .EventId(eventId)
+                .Summary(summary)
+                .Description(description)
+                .Start(new Date(2014, 8, 5))
+                .End(new Date(2014, 8, 6))
+                .Conferencing(conferencingProfileId);
+
+            this.Client.UpsertEvent(CalendarId, builder);
+        }
+
+        [Test]
+        public void CanUpsertExplicitConferencing()
+        {
+            const string eventId = "qTtZdczOccgaPncGJaCiLg";
+            const string summary = "Board meeting";
+            const string description = "Discuss plans for the next quarter";
+            const string startTimeString = "2014-08-05";
+            const string endTimeString = "2014-08-06";
+            const string conferencingProvider = "Meetings Co.";
+            const string conferencingUrl = "https://meetings.co/join/abc";
+
+            this.Http.Stub(
+                HttpPost
+                .Url("https://api.cronofy.com/v1/calendars/" + CalendarId + "/events")
+                .RequestHeader("Authorization", "Bearer " + AccessToken)
+                .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                .RequestBodyFormat(
+                    "{{\"event_id\":\"{0}\"," +
+                    "\"conferencing\":{{\"profile_id\":\"explicit\",\"provider_description\":\"{5}\",\"join_url\":\"{6}\"}}," +
+                    "\"summary\":\"{1}\"," +
+                    "\"description\":\"{2}\"," +
+                    "\"start\":{{\"time\":\"{3}\",\"tzid\":\"Etc/UTC\"}}," +
+                    "\"end\":{{\"time\":\"{4}\",\"tzid\":\"Etc/UTC\"}}" +
+                    "}}",
+                    eventId,
+                    summary,
+                    description,
+                    startTimeString,
+                    endTimeString,
+                    conferencingProvider,
+                    conferencingUrl)
+                .ResponseCode(202));
+
+            var builder = new UpsertEventRequestBuilder()
+                .EventId(eventId)
+                .Summary(summary)
+                .Description(description)
+                .Start(new Date(2014, 8, 5))
+                .End(new Date(2014, 8, 6))
+                .ExplicitConferencing(conferencingProvider, conferencingUrl);
+
+            this.Client.UpsertEvent(CalendarId, builder);
+        }
     }
 }


### PR DESCRIPTION
Adds support for Conferencing and Interaction Subscriptions (for `conferencing_assigned`) to Upsert Event calls.

Still to do for full conferencing support:
- [ ] Expose `integrated_conferencing_available` on calendars
- [ ] Expose `conferencing_profiles` on User Info
- [ ] Generation of conferencing auth URLs