### PR TITLE
Support multi-value HMAC headers

### DIFF
--- a/src/Cronofy/CronofyOAuthClient.cs
+++ b/src/Cronofy/CronofyOAuthClient.cs
@@ -354,17 +354,25 @@ namespace Cronofy
         }
 
         /// <inheritdoc/>
-        public bool HmacMatches(string sha256Hmac, byte[] requestBytes)
+        public bool HmacMatches(string cronofyHmacSha256HeaderValue, byte[] requestBytes)
         {
-            Preconditions.NotEmpty("sha256Hmac", sha256Hmac);
+            Preconditions.NotEmpty(nameof(cronofyHmacSha256HeaderValue), cronofyHmacSha256HeaderValue);
+
+            var headerHmacs = cronofyHmacSha256HeaderValue.Split(',').Select(s => s.Trim()).ToList();
+            if (!headerHmacs.Any())
+            {
+                return false;
+            }
 
             var keyBytes = Encoding.UTF8.GetBytes(this.clientSecret);
-
+            string sha256Hmac;
             using (var hmacsha256 = new HMACSHA256(keyBytes))
             {
                 var requestHash = hmacsha256.ComputeHash(requestBytes);
-                return sha256Hmac == Convert.ToBase64String(requestHash);
+                sha256Hmac = Convert.ToBase64String(requestHash);
             }
+
+            return headerHmacs.Contains(sha256Hmac);
         }
 
         /// <inheritdoc/>

--- a/src/Cronofy/ICronofyOAuthClient.cs
+++ b/src/Cronofy/ICronofyOAuthClient.cs
@@ -101,11 +101,11 @@ namespace Cronofy
         void RevokeToken(string token);
 
         /// <summary>
-        /// Validates whether the provided HMAC matches the one generated for
+        /// Validates whether the provided HMAC header matches the one generated for
         /// the corresponding request bytes.
         /// </summary>
-        /// <param name="sha256Hmac">
-        /// The HMAC taken from the <c>Cronofy-HMAC-SHA256</c> header of
+        /// <param name="cronofyHmacSha256HeaderValue">
+        /// The value of the <c>Cronofy-HMAC-SHA256</c> header of
         /// the request, must not be null or empty.
         /// </param>
         /// <param name="requestBytes">
@@ -115,9 +115,9 @@ namespace Cronofy
         /// <c>true</c> if the HMAC matches, otherwise <c>false</c>.
         /// </returns>
         /// <exception cref="ArgumentException">
-        /// Thrown if <paramref name="sha256Hmac"/> is null or empty.
+        /// Thrown if <paramref name="cronofyHmacSha256HeaderValue"/> is null or empty.
         /// </exception>
-        bool HmacMatches(string sha256Hmac, byte[] requestBytes);
+        bool HmacMatches(string cronofyHmacSha256HeaderValue, byte[] requestBytes);
 
         /// <summary>
         /// Generates a link for real time scheduling based on the request provided.

--- a/test/Cronofy.Test/PushNotificationTests/HmacVerification.cs
+++ b/test/Cronofy.Test/PushNotificationTests/HmacVerification.cs
@@ -9,25 +9,42 @@
         private const string ClientId = "abcdef123456";
         private const string ClientSecret = "pDY0Oi7TJSP2hfNmZNkm5";
 
+        private const string RequestBody = "{\"example\":\"well-known\"}";
+
+        private byte[] requestBytes = Encoding.UTF8.GetBytes(RequestBody);
+
         private CronofyOAuthClient client;
-        private StubHttpClient http;
 
         [SetUp]
         public void SetUp()
         {
             this.client = new CronofyOAuthClient(ClientId, ClientSecret);
-            this.http = new StubHttpClient();
-
-            this.client.HttpClient = this.http;
         }
 
         [Test]
-        public void CanVerifyHmac()
+        public void CanVerifyValidHmac()
         {
-            var encoding = Encoding.UTF8;
-            var requestBytes = Encoding.UTF8.GetBytes("{\"example\":\"well-known\"}");
+            var validHmac = "6r2/HjBkqymGegX0wOfifieeUXbbHwtV/LohHS+jv6c=";
+            var result = this.client.HmacMatches(validHmac, this.requestBytes);
+            Assert.IsTrue(result);
+        }
 
-            Assert.IsTrue(this.client.HmacMatches("6r2/HjBkqymGegX0wOfifieeUXbbHwtV/LohHS+jv6c=", requestBytes));
+        [Test]
+        public void CanRejectInvalidHmac()
+        {
+            var invalidHmac = "PNNVJ9J2e8N174koxcKDzktZ9Qkt8YUzP+V+l5lG8F4=";
+            var result = this.client.HmacMatches(invalidHmac, this.requestBytes);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void CanVerifyMultiValueHmac()
+        {
+            var multiValueHmac = "PNNVJ9J2e8N174koxcKDzktZ9Qkt8YUzP+V+l5lG8F4=,6r2/HjBkqymGegX0wOfifieeUXbbHwtV/LohHS+jv6c=";
+            var result = this.client.HmacMatches(multiValueHmac, this.requestBytes);
+
+            Assert.IsTrue(result);
         }
     }
 }


### PR DESCRIPTION
Simplifies cases where clients have multiple currently valid secrets, where we send multiple HMAC values for webhooks.