### PR TITLE
Add support for creating and attaching files to events

### DIFF
--- a/src/Cronofy.Example/Program.cs
+++ b/src/Cronofy.Example/Program.cs
@@ -42,6 +42,7 @@
             var client = new CronofyAccountClient(accessToken);
 
             FetchAndPrintCalendars(client);
+            FetchAndPrintEvents(client);
 
             const string EventId = "CronofyExample";
 
@@ -191,9 +192,12 @@
 
             var attachment = oaClient.CreateAttachment(new Requests.CreateAttachmentRequest
             {
-                FileName = "example.txt",
-                ContentType = "text/plain",
-                Base64Content = Convert.ToBase64String(attachmentContent),
+                Attachment = new Requests.CreateAttachmentRequest.AttachmentSummary
+                {
+                    FileName = "example.txt",
+                    ContentType = "text/plain",
+                    Base64Content = Convert.ToBase64String(attachmentContent),
+                },
             });
 
             Console.WriteLine("Attachment created");
@@ -254,7 +258,14 @@
             }
 
             Console.WriteLine();
+        }
 
+        /// <summary>
+        /// Fetches a list of all of the users events and prints a summary to the console.
+        /// </summary>
+        /// <param name="client">Account client to use to read the list of events.</param>
+        private static void FetchAndPrintEvents(CronofyAccountClient client)
+        {
             Console.WriteLine("Fetching events...");
             var events = client.GetEvents();
 

--- a/src/Cronofy/Attachment.cs
+++ b/src/Cronofy/Attachment.cs
@@ -1,0 +1,98 @@
+namespace Cronofy
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Class for the deserialization of an attachment summary
+    /// response.
+    /// </summary>
+    public sealed class Attachment
+    {
+        /// <summary>
+        /// Gets or sets the attachment ID.
+        /// </summary>
+        /// <value>
+        /// The ID of the attachment.
+        /// </value>
+        [JsonProperty("attachment_id")]
+        public string AttachmentId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file name for the attachment.
+        /// </summary>
+        /// <value>
+        /// The file name for the attachment.
+        /// </value>
+        [JsonProperty("file_name")]
+        public string FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MIME content type for the attachment.
+        /// </summary>
+        /// <value>
+        /// The MIME content type for the attachment.
+        /// </value>
+        [JsonProperty("content_type")]
+        public string ContentType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MD5 hash of the attachment content.
+        /// </summary>
+        /// <value>
+        /// The MD5 hash of the attachment content.
+        /// </value>
+        [JsonProperty("md5")]
+        public string MD5 { get; set; }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj is Attachment && this.Equals((Attachment)obj);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return this.AttachmentId.GetHashCode();
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="Cronofy.Attachment"/>
+        /// is equal to the current <see cref="Cronofy.Attachment"/>.
+        /// </summary>
+        /// <param name="other">
+        /// The <see cref="Cronofy.Attachment"/> to compare with the current
+        /// <see cref="Cronofy.Attachment"/>.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if the specified <see cref="Cronofy.Attachment"/> is
+        /// equal to the current <see cref="Cronofy.Attachment"/>; otherwise,
+        /// <c>false</c>.
+        /// </returns>
+        public bool Equals(Attachment other)
+        {
+            return this.AttachmentId == other.AttachmentId && this.FileName == other.FileName
+             && this.ContentType == other.ContentType && this.MD5 == other.MD5;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return string.Format(
+                "<{0} AttachmentId={1}, FileName={2}>",
+                this.GetType(),
+                this.AttachmentId,
+                this.FileName);
+        }
+    }
+}

--- a/src/Cronofy/Attachment.cs
+++ b/src/Cronofy/Attachment.cs
@@ -14,7 +14,6 @@ namespace Cronofy
         /// <value>
         /// The ID of the attachment.
         /// </value>
-        [JsonProperty("attachment_id")]
         public string AttachmentId { get; set; }
 
         /// <summary>
@@ -23,7 +22,6 @@ namespace Cronofy
         /// <value>
         /// The file name for the attachment.
         /// </value>
-        [JsonProperty("file_name")]
         public string FileName { get; set; }
 
         /// <summary>
@@ -32,7 +30,6 @@ namespace Cronofy
         /// <value>
         /// The MIME content type for the attachment.
         /// </value>
-        [JsonProperty("content_type")]
         public string ContentType { get; set; }
 
         /// <summary>
@@ -41,7 +38,6 @@ namespace Cronofy
         /// <value>
         /// The MD5 hash of the attachment content.
         /// </value>
-        [JsonProperty("md5")]
         public string MD5 { get; set; }
 
         /// <inheritdoc/>

--- a/src/Cronofy/CronofyOAuthClient.cs
+++ b/src/Cronofy/CronofyOAuthClient.cs
@@ -522,9 +522,10 @@ namespace Cronofy
         public Attachment CreateAttachment(CreateAttachmentRequest createAttachmentRequest)
         {
             Preconditions.NotNull(nameof(createAttachmentRequest), createAttachmentRequest);
-            Preconditions.NotEmpty(nameof(createAttachmentRequest.FileName), createAttachmentRequest.FileName);
-            Preconditions.NotEmpty(nameof(createAttachmentRequest.ContentType), createAttachmentRequest.ContentType);
-            Preconditions.NotEmpty(nameof(createAttachmentRequest.Base64Content), createAttachmentRequest.Base64Content);
+            Preconditions.NotNull(nameof(createAttachmentRequest.Attachment), createAttachmentRequest.Attachment);
+            Preconditions.NotEmpty(nameof(createAttachmentRequest.Attachment.FileName), createAttachmentRequest.Attachment.FileName);
+            Preconditions.NotEmpty(nameof(createAttachmentRequest.Attachment.ContentType), createAttachmentRequest.Attachment.ContentType);
+            Preconditions.NotEmpty(nameof(createAttachmentRequest.Attachment.Base64Content), createAttachmentRequest.Attachment.Base64Content);
 
             var request = new HttpRequest
             {

--- a/src/Cronofy/CronofyOAuthClient.cs
+++ b/src/Cronofy/CronofyOAuthClient.cs
@@ -518,6 +518,28 @@ namespace Cronofy
             return elementTokenResponse.ToElementToken();
         }
 
+        /// <inheritdoc/>
+        public Attachment CreateAttachment(CreateAttachmentRequest createAttachmentRequest)
+        {
+            Preconditions.NotNull(nameof(createAttachmentRequest), createAttachmentRequest);
+            Preconditions.NotEmpty(nameof(createAttachmentRequest.FileName), createAttachmentRequest.FileName);
+            Preconditions.NotEmpty(nameof(createAttachmentRequest.ContentType), createAttachmentRequest.ContentType);
+            Preconditions.NotEmpty(nameof(createAttachmentRequest.Base64Content), createAttachmentRequest.Base64Content);
+
+            var request = new HttpRequest
+            {
+                Method = "POST",
+                Url = this.urlProvider.AttachmentsUrl,
+            };
+
+            request.AddOAuthAuthorization(this.clientSecret);
+            request.SetJsonBody(createAttachmentRequest);
+
+            var attachmentResponse = this.HttpClient.GetJsonResponse<AttachmentResponse>(request);
+
+            return attachmentResponse.ToAttachment();
+        }
+
         /// <summary>
         /// Builder class for authorization URLs.
         /// </summary>

--- a/src/Cronofy/ICronofyOAuthClient.cs
+++ b/src/Cronofy/ICronofyOAuthClient.cs
@@ -397,6 +397,18 @@ namespace Cronofy
         /// </exception>
         IAuthorizationUrlBuilder GetEnterpriseConnectAuthorizationUrlBuilder(string redirectUri);
 
+        /// <summary>
+        /// Creates a new attachment that can be added to an event as part of an upsert operation.
+        /// </summary>
+        /// <param name="createAttachmentRequest">
+        /// The details of the attachment to be created.
+        /// </param>
+        /// <returns>
+        /// The created attachment.
+        /// </returns>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown if <paramref name="createAttachmentRequest"/> is null or empty.
+        /// </exception>
         Attachment CreateAttachment(CreateAttachmentRequest createAttachmentRequest);
     }
 }

--- a/src/Cronofy/ICronofyOAuthClient.cs
+++ b/src/Cronofy/ICronofyOAuthClient.cs
@@ -396,5 +396,7 @@ namespace Cronofy
         /// Thrown if <paramref name="redirectUri"/> is null or empty.
         /// </exception>
         IAuthorizationUrlBuilder GetEnterpriseConnectAuthorizationUrlBuilder(string redirectUri);
+
+        Attachment CreateAttachment(CreateAttachmentRequest createAttachmentRequest);
     }
 }

--- a/src/Cronofy/Requests/CreateAttachmentRequest.cs
+++ b/src/Cronofy/Requests/CreateAttachmentRequest.cs
@@ -1,0 +1,86 @@
+namespace Cronofy.Requests
+{
+    using Newtonsoft.Json;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Class for the serialization of a create attachment request.
+    /// </summary>
+    public sealed class CreateAttachmentRequest
+    {
+        /// <summary>
+        /// Gets or sets the file name for the attachment.
+        /// </summary>
+        /// <value>
+        /// The file name for the attachment.
+        /// </value>
+        [JsonProperty("file_name")]
+        public string FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MIME content type for the attachment.
+        /// </summary>
+        /// <value>
+        /// The MIME content type for the attachment.
+        /// </value>
+        [JsonProperty("content_type")]
+        public string ContentType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Base64-encoded content of the attachment.
+        /// </summary>
+        /// <value>
+        /// The Base64-encoded content of the attachment.
+        /// </value>
+        [JsonProperty("base64_content")]
+        public string Base64Content { get; set; }
+
+        /// <summary>
+        /// Class for the serialization of attachment subscriptions.
+        /// </summary>
+        public sealed class RequestSubscription
+        {
+            /// <summary>
+            /// Gets or sets the type of the subscription.
+            /// </summary>
+            /// <value>
+            /// The type of the subscription.
+            /// </value>
+            [JsonProperty("type")]
+            public string Type { get; set; }
+
+            /// <summary>
+            /// Gets or sets the destination URI Cronofy will call when the subscription is triggered.
+            /// </summary>
+            /// <value>
+            /// The destination URI Cronofy will call when the subscription is triggered.
+            /// </value>
+            [JsonProperty("uri")]
+            public string Uri { get; set; }
+
+            /// <summary>
+            /// Gets or sets the interactions subscribed to.
+            /// </summary>
+            /// <value>
+            /// The interactions subscribed to.
+            /// </value>
+            [JsonProperty("interactions")]
+            public IEnumerable<Interaction> Interactions { get; set; }
+
+            /// <summary>
+            /// Class for the serialization of event subscription interactions.
+            /// </summary>
+            public sealed class Interaction
+            {
+                /// <summary>
+                /// Gets or sets the type of the interaction.
+                /// </summary>
+                /// <value>
+                /// The type of the interaction.
+                /// </value>
+                [JsonProperty("type")]
+                public string Type { get; set; }
+            }
+        }
+    }
+}

--- a/src/Cronofy/Requests/CreateAttachmentRequest.cs
+++ b/src/Cronofy/Requests/CreateAttachmentRequest.cs
@@ -1,7 +1,7 @@
 namespace Cronofy.Requests
 {
-    using Newtonsoft.Json;
     using System.Collections.Generic;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// Class for the serialization of a create attachment request.

--- a/src/Cronofy/Requests/CreateAttachmentRequest.cs
+++ b/src/Cronofy/Requests/CreateAttachmentRequest.cs
@@ -9,31 +9,55 @@ namespace Cronofy.Requests
     public sealed class CreateAttachmentRequest
     {
         /// <summary>
-        /// Gets or sets the file name for the attachment.
+        /// Gets or sets the summary of the attachment to be created.
         /// </summary>
         /// <value>
-        /// The file name for the attachment.
+        /// The summary of the attachment to be created.
         /// </value>
-        [JsonProperty("file_name")]
-        public string FileName { get; set; }
+        [JsonProperty("attachment")]
+        public AttachmentSummary Attachment { get; set; }
 
         /// <summary>
-        /// Gets or sets the MIME content type for the attachment.
+        /// Gets or sets the list of subscriptions to be added to the attachment.
         /// </summary>
         /// <value>
-        /// The MIME content type for the attachment.
+        /// The list of subscriptions to be added to the attachment.
         /// </value>
-        [JsonProperty("content_type")]
-        public string ContentType { get; set; }
+        [JsonProperty("subscriptions")]
+        public IEnumerable<RequestSubscription> Subscriptions { get; set; }
 
         /// <summary>
-        /// Gets or sets the Base64-encoded content of the attachment.
+        /// Class for the serialization of attachment summary.
         /// </summary>
-        /// <value>
-        /// The Base64-encoded content of the attachment.
-        /// </value>
-        [JsonProperty("base64_content")]
-        public string Base64Content { get; set; }
+        public sealed class AttachmentSummary
+        {
+            /// <summary>
+            /// Gets or sets the file name for the attachment.
+            /// </summary>
+            /// <value>
+            /// The file name for the attachment.
+            /// </value>
+            [JsonProperty("file_name")]
+            public string FileName { get; set; }
+
+            /// <summary>
+            /// Gets or sets the MIME content type for the attachment.
+            /// </summary>
+            /// <value>
+            /// The MIME content type for the attachment.
+            /// </value>
+            [JsonProperty("content_type")]
+            public string ContentType { get; set; }
+
+            /// <summary>
+            /// Gets or sets the Base64-encoded content of the attachment.
+            /// </summary>
+            /// <value>
+            /// The Base64-encoded content of the attachment.
+            /// </value>
+            [JsonProperty("base64_content")]
+            public string Base64Content { get; set; }
+        }
 
         /// <summary>
         /// Class for the serialization of attachment subscriptions.

--- a/src/Cronofy/Requests/UpsertEventRequest.cs
+++ b/src/Cronofy/Requests/UpsertEventRequest.cs
@@ -74,6 +74,15 @@
         public IEnumerable<RequestSubscription> Subscriptions { get; set; }
 
         /// <summary>
+        /// Gets or sets the attachments for the event.
+        /// </summary>
+        /// <value>
+        /// The attachments for the event.
+        /// </value>
+        [JsonProperty("attachments")]
+        public IEnumerable<Attachment> Attachments { get; set; }
+
+        /// <summary>
         /// Class for the serialization of the attendees for an upsert event
         /// request.
         /// </summary>
@@ -204,6 +213,21 @@
                 [JsonProperty("type")]
                 public string Type { get; set; }
             }
+        }
+
+        /// <summary>
+        /// Class for the serialization of an events individual attachment.
+        /// </summary>
+        public sealed class Attachment
+        {
+            /// <summary>
+            /// Gets or sets the id of the attachment.
+            /// </summary>
+            /// <value>
+            /// The id of the attachment.
+            /// </value>
+            [JsonProperty("attachment_id")]
+            public string AttachmentId { get; set; }
         }
     }
 }

--- a/src/Cronofy/Responses/AttachmentResponse.cs
+++ b/src/Cronofy/Responses/AttachmentResponse.cs
@@ -1,0 +1,48 @@
+namespace Cronofy.Responses
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Class for the deserialization of an availability response.
+    /// </summary>
+    internal sealed class AttachmentResponse
+    {
+        /// <summary>
+        /// Gets or sets the available periods of the response.
+        /// </summary>
+        /// <value>
+        /// The available periods of the response.
+        /// </value>
+        [JsonProperty("attachment")]
+        public AttachmentSummary Attachment { get; set; }
+
+        internal sealed class AttachmentSummary
+        {
+            [JsonProperty("attachment_id")]
+            public string AttachmentId { get; set; }
+
+            [JsonProperty("file_name")]
+            public string FileName { get; set; }
+
+            [JsonProperty("content_type")]
+            public string ContentType { get; set; }
+
+            [JsonProperty("md5")]
+            public string MD5 { get; set; }
+        }
+
+        public Attachment ToAttachment()
+        {
+            return new Attachment
+            {
+                AttachmentId = this.Attachment.AttachmentId,
+                FileName = this.Attachment.FileName,
+                ContentType = this.Attachment.ContentType,
+                MD5 = this.Attachment.MD5,
+            };
+        }
+    }
+}

--- a/src/Cronofy/Responses/AttachmentResponse.cs
+++ b/src/Cronofy/Responses/AttachmentResponse.cs
@@ -19,21 +19,10 @@ namespace Cronofy.Responses
         [JsonProperty("attachment")]
         public AttachmentSummary Attachment { get; set; }
 
-        internal sealed class AttachmentSummary
-        {
-            [JsonProperty("attachment_id")]
-            public string AttachmentId { get; set; }
-
-            [JsonProperty("file_name")]
-            public string FileName { get; set; }
-
-            [JsonProperty("content_type")]
-            public string ContentType { get; set; }
-
-            [JsonProperty("md5")]
-            public string MD5 { get; set; }
-        }
-
+        /// <summary>
+        /// Converts the response into an attachment.
+        /// </summary>
+        /// <returns>The response as an attachment.</returns>
         public Attachment ToAttachment()
         {
             return new Attachment
@@ -43,6 +32,48 @@ namespace Cronofy.Responses
                 ContentType = this.Attachment.ContentType,
                 MD5 = this.Attachment.MD5,
             };
+        }
+
+        /// <summary>
+        /// Class for the serialization of attachment summary.
+        /// </summary>
+        internal sealed class AttachmentSummary
+        {
+            /// <summary>
+            /// Gets or sets the id of the attachment.
+            /// </summary>
+            /// <value>
+            /// The id of the attachment.
+            /// </value>
+            [JsonProperty("attachment_id")]
+            public string AttachmentId { get; set; }
+
+            /// <summary>
+            /// Gets or sets the name of the attachment file.
+            /// </summary>
+            /// <value>
+            /// The name of the attachment file.
+            /// </value>
+            [JsonProperty("file_name")]
+            public string FileName { get; set; }
+
+            /// <summary>
+            /// Gets or sets the MIME content type of the attachment.
+            /// </summary>
+            /// <value>
+            /// The MIME content type of the attachment.
+            /// </value>
+            [JsonProperty("content_type")]
+            public string ContentType { get; set; }
+
+            /// <summary>
+            /// Gets or sets the MD5 hash of the attachment file content.
+            /// </summary>
+            /// <value>
+            /// The MD5 hash of the attachment file content.
+            /// </value>
+            [JsonProperty("md5")]
+            public string MD5 { get; set; }
         }
     }
 }

--- a/src/Cronofy/Responses/AttachmentResponse.cs
+++ b/src/Cronofy/Responses/AttachmentResponse.cs
@@ -11,10 +11,10 @@ namespace Cronofy.Responses
     internal sealed class AttachmentResponse
     {
         /// <summary>
-        /// Gets or sets the available periods of the response.
+        /// Gets or sets the created attachment.
         /// </summary>
         /// <value>
-        /// The available periods of the response.
+        /// The created attachment.
         /// </value>
         [JsonProperty("attachment")]
         public AttachmentSummary Attachment { get; set; }

--- a/src/Cronofy/UpsertEventRequestBuilder.cs
+++ b/src/Cronofy/UpsertEventRequestBuilder.cs
@@ -133,6 +133,11 @@
         private ICollection<UpsertEventRequest.RequestSubscription> subscriptions;
 
         /// <summary>
+        /// The attachments for the event.
+        /// </summary>
+        private ICollection<UpsertEventRequest.Attachment> attachments;
+
+        /// <summary>
         /// Initializes a new instance of the
         /// <see cref="Cronofy.UpsertEventRequestBuilder"/> class.
         /// </summary>
@@ -142,6 +147,7 @@
             this.endTimeZoneId = TimeZoneIdentifiers.Default;
             this.addedAttendees = new List<UpsertEventRequest.RequestAttendee>();
             this.removedAttendees = new List<UpsertEventRequest.RequestAttendee>();
+            this.attachments = new List<UpsertEventRequest.Attachment>();
         }
 
         /// <summary>
@@ -755,6 +761,25 @@
             return this;
         }
 
+        /// <summary>
+        /// Adds an attachment to the event.
+        /// </summary>
+        /// <returns>
+        /// A reference to the modified builder.
+        /// </returns>
+        /// <param name="attachmentId">The identifier of the attachment to be added.</param>
+        public UpsertEventRequestBuilder AddAttachment(string attachmentId)
+        {
+            Preconditions.NotEmpty("attachmentId", attachmentId);
+
+            this.attachments.Add(new UpsertEventRequest.Attachment
+            {
+                AttachmentId = attachmentId,
+            });
+
+            return this;
+        }
+
         /// <inheritdoc/>
         public UpsertEventRequest Build()
         {
@@ -806,6 +831,11 @@
             if (this.removedAttendees.Any())
             {
                 request.Attendees.Remove = this.removedAttendees;
+            }
+
+            if (this.attachments.Any())
+            {
+                request.Attachments = this.attachments;
             }
 
             return request;

--- a/src/Cronofy/UrlProvider.cs
+++ b/src/Cronofy/UrlProvider.cs
@@ -171,6 +171,11 @@ namespace Cronofy
         private const string ConferencingServiceAuthorizationUrlFormat = "https://api{0}.cronofy.com/v1/conferencing_service_authorizations";
 
         /// <summary>
+        /// The URL of the Attachments endpoint.
+        /// </summary>
+        private const string AttachmentsUrlFormat = "https://api{0}.cronofy.com/v1/attachments";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="UrlProvider"/> class.
         /// </summary>
         /// <param name="dataCenter">
@@ -218,6 +223,7 @@ namespace Cronofy
             this.ProvisionApplicationUrl = string.Format(ProvisionApplicationUrlFormat, suffix);
             this.ElementTokensUrl = string.Format(ElementTokensUrlFormat, suffix);
             this.ConferencingServiceAuthorizationUrl = string.Format(ConferencingServiceAuthorizationUrlFormat, suffix);
+            this.AttachmentsUrl = string.Format(AttachmentsUrlFormat, suffix);
         }
 
         /// <summary>
@@ -567,5 +573,11 @@ namespace Cronofy
         /// </summary>
         /// <value>The conferencing service authorization URL.</value>
         public string ConferencingServiceAuthorizationUrl { get; private set; }
+
+        /// <summary>
+        /// Gets the attachments URL.
+        /// </summary>
+        /// <value>The attachments URL.</value>
+        public string AttachmentsUrl { get; private set; }
     }
 }

--- a/test/Cronofy.Test/CronofyOAuthClientTests/Attachments.cs
+++ b/test/Cronofy.Test/CronofyOAuthClientTests/Attachments.cs
@@ -5,7 +5,7 @@ namespace Cronofy.Test.CronofyOAuthClientTests
     [TestFixture]
     public sealed class Attachments
     {
-      private const string ClientId = "abcdef123456";
+        private const string ClientId = "abcdef123456";
         private const string ClientSecret = "s3cr3t1v3";
 
         private CronofyOAuthClient client;

--- a/test/Cronofy.Test/CronofyOAuthClientTests/Attachments.cs
+++ b/test/Cronofy.Test/CronofyOAuthClientTests/Attachments.cs
@@ -1,0 +1,66 @@
+namespace Cronofy.Test.CronofyOAuthClientTests
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public sealed class Attachments
+    {
+      private const string ClientId = "abcdef123456";
+        private const string ClientSecret = "s3cr3t1v3";
+
+        private CronofyOAuthClient client;
+        private StubHttpClient http;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.client = new CronofyOAuthClient(ClientId, ClientSecret);
+            this.http = new StubHttpClient();
+
+            this.client.HttpClient = this.http;
+        }
+
+        [Test]
+        public void CanCreateAttachment()
+        {
+            const string AttachmentId = "attachment-123";
+            const string FileName = "file_name.txt";
+            const string ContentType = "plain/text";
+            const string Base64Content = "VGVzdGluZyBGaWxlIENvbnRlbnQ=";
+            const string MD5 = "ac79653edeb65ab5563585f2d5f14fe9";
+
+            this.http.Stub(
+                HttpPost
+                    .Url("https://api.cronofy.com/v1/attachments")
+                    .RequestHeader("Authorization", string.Format("Bearer {0}", ClientSecret))
+                    .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                    .RequestBodyFormat(
+                        "{{\"attachment\":{{\"file_name\":\"{0}\",\"content_type\":\"{1}\",\"base64_content\":\"{2}\"}}}}",
+                        FileName, ContentType, Base64Content)
+                    .ResponseCode(200)
+                    .ResponseBodyFormat(
+                        "{{\"attachment\":{{\"attachment_id\":\"{0}\",\"file_name\":\"{1}\",\"content_type\":\"{2}\",\"md5\":\"{3}\"}}}}",
+                        AttachmentId, FileName, ContentType, MD5));
+
+            var actualAttachment = this.client.CreateAttachment(new Requests.CreateAttachmentRequest
+            {
+                Attachment = new Requests.CreateAttachmentRequest.AttachmentSummary
+                {
+                    FileName = FileName,
+                    ContentType = ContentType,
+                    Base64Content = Base64Content,
+                },
+            });
+
+            var expectedAttachment = new Attachment
+            {
+                AttachmentId = AttachmentId,
+                FileName = FileName,
+                ContentType = ContentType,
+                MD5 = MD5,
+            };
+
+            Assert.AreEqual(expectedAttachment, actualAttachment);
+        }
+    }
+}


### PR DESCRIPTION
Adds support for [attachments](https://docs.cronofy.com/developers/api-alpha/attachments/) to the SDK.

Additionally the example has been updated to demonstrate usage of the new SDK functionality. 