### PR TITLE
Include error response bodies on API call failures

### DIFF
--- a/src/Cronofy/CronofyAccountClient.cs
+++ b/src/Cronofy/CronofyAccountClient.cs
@@ -311,13 +311,7 @@ namespace Cronofy
             var requestBody = new { delete_all = true };
             request.SetJsonBody(requestBody);
 
-            var response = this.HttpClient.GetResponse(request);
-
-            if (response.Code != 202)
-            {
-                // TODO More useful exceptions for validation errors
-                throw new CronofyException("Request failed");
-            }
+            this.HttpClient.GetValidResponse(request);
         }
 
         /// <inheritdoc/>
@@ -334,13 +328,7 @@ namespace Cronofy
             var requestBody = new { calendar_ids = calendarIds };
             request.SetJsonBody(requestBody);
 
-            var response = this.HttpClient.GetResponse(request);
-
-            if (response.Code != 202)
-            {
-                // TODO More useful exceptions for validation errors
-                throw new CronofyException("Request failed");
-            }
+            this.HttpClient.GetValidResponse(request);
         }
 
         /// <inheritdoc/>
@@ -358,12 +346,7 @@ namespace Cronofy
             var requestBody = new DeleteExternalEventRequest { EventUid = eventUid };
             request.SetJsonBody(requestBody);
 
-            var response = this.HttpClient.GetResponse(request);
-
-            if (response.Code != 202)
-            {
-                throw new CronofyException("Request failed");
-            }
+            this.HttpClient.GetValidResponse(request);
         }
 
         /// <inheritdoc/>
@@ -381,12 +364,7 @@ namespace Cronofy
             var requestBody = new { status = status.ToString().ToLower() };
             request.SetJsonBody(requestBody);
 
-            var response = this.HttpClient.GetResponse(request);
-
-            if (response.Code != 202)
-            {
-                throw new CronofyException("Request failed");
-            }
+            this.HttpClient.GetValidResponse(request);
         }
 
         /// <inheritdoc/>

--- a/src/Cronofy/CronofyOAuthClient.cs
+++ b/src/Cronofy/CronofyOAuthClient.cs
@@ -179,12 +179,7 @@ namespace Cronofy
 
             request.SetJsonBody(requestBody);
 
-            var response = this.HttpClient.GetResponse(request);
-
-            if (response.Code != 200)
-            {
-                throw new CronofyResponseException("Request failed", response);
-            }
+            this.HttpClient.GetValidResponse(request);
         }
 
         /// <inheritdoc/>

--- a/src/Cronofy/ICronofyAccountClient.cs
+++ b/src/Cronofy/ICronofyAccountClient.cs
@@ -241,9 +241,6 @@
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         void UpsertEvent(string calendarId, IBuilder<UpsertEventRequest> eventBuilder);
 
         /// <summary>
@@ -263,9 +260,6 @@
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         void UpsertEvent(string calendarId, UpsertEventRequest eventRequest);
 
         /// <summary>
@@ -285,9 +279,6 @@
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         void DeleteEvent(string calendarId, string eventId);
 
         /// <summary>
@@ -296,9 +287,6 @@
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         void DeleteAllEvents();
 
         /// <summary>
@@ -313,9 +301,6 @@
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         void DeleteAllEventsForCalendars(params string[] calendarIds);
 
         /// <summary>
@@ -335,9 +320,6 @@
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         void DeleteExternalEvent(string calendarId, string eventUid);
 
         /// <summary>
@@ -360,9 +342,6 @@
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         void ChangeParticipationStatus(string calendarId, string eventUid, ParticipationStatus status);
 
         /// <summary>
@@ -380,9 +359,6 @@
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         Channel CreateChannel(string callbackUrl);
 
         /// <summary>
@@ -401,9 +377,6 @@
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         Channel CreateChannel(IBuilder<CreateChannelRequest> channelBuilder);
 
         /// <summary>
@@ -421,9 +394,6 @@
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         Channel CreateChannel(CreateChannelRequest channelRequest);
 
         /// <summary>

--- a/src/Cronofy/ICronofyOAuthClient.cs
+++ b/src/Cronofy/ICronofyOAuthClient.cs
@@ -31,9 +31,6 @@ namespace Cronofy
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         OAuthToken GetTokenFromCode(string code, string redirectUri);
 
         /// <summary>
@@ -53,9 +50,6 @@ namespace Cronofy
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         OAuthToken GetTokenFromRefreshToken(string refreshToken);
 
         /// <summary>
@@ -74,9 +68,6 @@ namespace Cronofy
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        /// <remarks>
-        /// TODO Validation exceptions.
-        /// </remarks>
         OAuthToken ApplicationCalendar(string applicationCalendarId);
 
         /// <summary>

--- a/test/Cronofy.Test/CronofyAccountClientTests/BulkDelete.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/BulkDelete.cs
@@ -34,5 +34,54 @@
 
             this.Client.DeleteAllEventsForCalendars(calendar1, calendar2);
         }
+
+        [Test]
+        public void DeleteAllThrowsCronofyResponseExceptionOnFailure()
+        {
+            // Realistically this method should not result in validation errors as there are no user-provided inputs.
+            // But we can simulate error case handling here anyway to ensure this method is handling validation failures.
+            this.Http.Stub(
+                HttpDelete
+                    .Url("https://api.cronofy.com/v1/events")
+                    .RequestHeader("Authorization", "Bearer " + AccessToken)
+                    .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                    .RequestBody("{\"delete_all\":true}")
+                    .ResponseCode(422)
+                    .ResponseBody(
+                        "{\"errors:\":{\"delete_all\":[{\"key\":\"errors.must_be_boolean\",\"description\":\"must be a boolean value, either true or false\"}}"));
+
+            var exception = Assert.Throws<CronofyResponseException>(() => this.Client.DeleteAllEvents());
+
+            Assert.AreEqual(exception.Message, "Validation failed");
+            Assert.AreEqual(exception.Response.Code, 422);
+            Assert.AreEqual(
+                exception.Response.Body,
+                "{\"errors:\":{\"delete_all\":[{\"key\":\"errors.must_be_boolean\",\"description\":\"must be a boolean value, either true or false\"}}");
+        }
+
+        [Test]
+        public void DeleteAllForCalendarsThrowsCronofyResponseExceptionOnFailure()
+        {
+            const string calendar1 = "cal_1234_5678";
+            const string calendar2 = "cal_8765_4321";
+
+            this.Http.Stub(
+                HttpDelete
+                    .Url("https://api.cronofy.com/v1/events")
+                    .RequestHeader("Authorization", "Bearer " + AccessToken)
+                    .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                    .RequestBodyFormat("{{\"calendar_ids\":[\"{0}\",\"{1}\"]}}", calendar1, calendar2)
+                    .ResponseCode(422)
+                    .ResponseBody(
+                        "{\"errors:\":{\"calendar_ids\":[{\"key\":\"errors.invalid_calendar_ids\",\"description\":\"One or more of the calendar IDs provided was invalid\"}}"));
+
+            var exception = Assert.Throws<CronofyResponseException>(() => this.Client.DeleteAllEventsForCalendars(calendar1, calendar2));
+
+            Assert.AreEqual(exception.Message, "Validation failed");
+            Assert.AreEqual(exception.Response.Code, 422);
+            Assert.AreEqual(
+                exception.Response.Body,
+                "{\"errors:\":{\"calendar_ids\":[{\"key\":\"errors.invalid_calendar_ids\",\"description\":\"One or more of the calendar IDs provided was invalid\"}}");
+        }
     }
 }

--- a/test/Cronofy.Test/CronofyAccountClientTests/ChangeParticipationStatus.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/ChangeParticipationStatus.cs
@@ -11,7 +11,7 @@
         [TestCase(ParticipationStatus.Accepted, "accepted")]
         [TestCase(ParticipationStatus.Tentative, "tentative")]
         [TestCase(ParticipationStatus.Declined, "declined")]
-        public void CanDeleteEvent(ParticipationStatus status, string expectedStatus)
+        public void CanChangeParticipationStatus(ParticipationStatus status, string expectedStatus)
         {
             this.Http.Stub(
                 HttpPost
@@ -22,6 +22,23 @@
                     .ResponseCode(202));
 
             this.Client.ChangeParticipationStatus(CalendarId, EventId, status);
+        }
+
+        [Test]
+        public void ChangeParticipationStatusThrowsCronofyResponseExceptionOnFailure()
+        {
+            this.Http.Stub(
+                HttpPost
+                    .Url("https://api.cronofy.com/v1/calendars/" + CalendarId + "/events/" + EventId + "/participation_status")
+                    .RequestHeader("Authorization", "Bearer " + AccessToken)
+                    .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                    .RequestBody("{\"status\":\"declined\"}")
+                    .ResponseCode(404));
+
+            var exception = Assert.Throws<CronofyResponseException>(() => this.Client.ChangeParticipationStatus(CalendarId, EventId, ParticipationStatus.Declined));
+
+            Assert.AreEqual(exception.Message, "Not found");
+            Assert.AreEqual(exception.Response.Code, 404);
         }
     }
 }

--- a/test/Cronofy.Test/CronofyAccountClientTests/DeleteEvent.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/DeleteEvent.cs
@@ -37,5 +37,49 @@
 
             this.Client.DeleteExternalEvent(CalendarId, eventUid);
         }
+
+        [Test]
+        public void DeleteEventThrowsCronofyResponseExceptionOnFailure()
+        {
+            const string eventId = "qTtZdczOccgaPncGJaCiLg";
+
+            // Assume the calendar could not be found
+            this.Http.Stub(
+                HttpDelete
+                    .Url("https://api.cronofy.com/v1/calendars/" + CalendarId + "/events")
+                    .RequestHeader("Authorization", "Bearer " + AccessToken)
+                    .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                    .RequestBodyFormat(@"{{""event_id"":""{0}""}}", eventId)
+                    .ResponseCode(404));
+
+            var exception = Assert.Throws<CronofyResponseException>(() => this.Client.DeleteEvent(CalendarId, eventId));
+
+            Assert.AreEqual(exception.Message, "Not found");
+            Assert.AreEqual(exception.Response.Code, 404);
+        }
+
+        [Test]
+        public void DeleteExternalEventThrowsCronofyResponseExceptionOnFailure()
+        {
+            const string eventUid = "external_event_id";
+
+            this.Http.Stub(
+                HttpDelete
+                    .Url("https://api.cronofy.com/v1/calendars/" + CalendarId + "/events")
+                    .RequestHeader("Authorization", "Bearer " + AccessToken)
+                    .RequestHeader("Content-Type", "application/json; charset=utf-8")
+                    .RequestBodyFormat(@"{{""event_uid"":""{0}""}}", eventUid)
+                    .ResponseCode(422)
+                    .ResponseBody(
+                        "{\"errors\":{\"event_uid\":[{\"key\":\"errors.must_be_external_event_uid\",\"description\":\"event uid must be a valid external event uid\"}]}"));
+
+            var exception = Assert.Throws<CronofyResponseException>(() => this.Client.DeleteExternalEvent(CalendarId, eventUid));
+
+            Assert.AreEqual(exception.Message, "Validation failed");
+            Assert.AreEqual(exception.Response.Code, 422);
+            Assert.AreEqual(
+                exception.Response.Body,
+                "{\"errors\":{\"event_uid\":[{\"key\":\"errors.must_be_external_event_uid\",\"description\":\"event uid must be a valid external event uid\"}]}");
+        }
     }
 }


### PR DESCRIPTION
Updates a number of older endpoints to make use of the `GetValidResponse` helper on the HTTP client class. This means we will include the response body of any API failures in the exception that gets raised.  This will enable consumers to understand more about what has gone wrong, and potentially filter out cases where the errors can be safely ignored (for example a `not_found` error when deleting an external event). This helper is already used for the majority of the other API operations, introducing it along these remaining paths will improve consistency.