### PR TITLE
Add support for the availability rules APIs

### DIFF
--- a/src/Cronofy.Example/Cronofy.Example.csproj
+++ b/src/Cronofy.Example/Cronofy.Example.csproj
@@ -23,7 +23,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Cronofy.Example/Program.cs
+++ b/src/Cronofy.Example/Program.cs
@@ -34,6 +34,11 @@
                 AttachmentsExample();
                 return;
             }
+            else if (args.Any(t => t == "availability-rules"))
+            {
+                AvailabilityRulesExample();
+                return;
+            }
 
             Console.Write("Enter access token: ");
             var accessToken = Console.ReadLine();
@@ -235,6 +240,90 @@
 
             client.DeleteEvent(calendarId, EventId);
             Console.WriteLine("Event deleted");
+            Console.WriteLine();
+
+            Console.WriteLine("Press enter to continue...");
+            Console.ReadLine();
+        }
+
+        /// <summary>
+        /// Availability rules usage example.
+        /// </summary>
+        private static void AvailabilityRulesExample()
+        {
+            Console.Write("Enter access token: ");
+            var accessToken = Console.ReadLine();
+
+            Console.WriteLine();
+            var client = new CronofyAccountClient(accessToken);
+
+            FetchAndPrintCalendars(client);
+
+            Console.Write("Enter calendar ID: ");
+            var calendarId = Console.ReadLine();
+            Console.WriteLine();
+
+            Console.WriteLine("Creating an example availability rule");
+            Console.WriteLine();
+
+            const string AvailabilityRuleId = "CSharpExampleAvailabilityRule";
+
+            client.UpsertAvailabilityRule(new Requests.UpsertAvailabilityRuleRequest
+            {
+                AvailabilityRuleId = AvailabilityRuleId,
+                TimeZoneId = "America/Chicago",
+                CalendarIds = new[] { calendarId },
+                WeeklyPeriods = new[]
+                {
+                    new Requests.UpsertAvailabilityRuleRequest.WeeklyPeriod
+                    {
+                        Day = "monday",
+                        StartTime = "09:30",
+                        EndTime = "12:30",
+                    },
+                    new Requests.UpsertAvailabilityRuleRequest.WeeklyPeriod
+                    {
+                        Day = "monday",
+                        StartTime = "14:00",
+                        EndTime = "17:00",
+                    },
+                    new Requests.UpsertAvailabilityRuleRequest.WeeklyPeriod
+                    {
+                        Day = "wednesday",
+                        StartTime = "09:30",
+                        EndTime = "12:30",
+                    },
+                },
+            });
+
+            Console.WriteLine("Availability rule created");
+            Console.WriteLine();
+
+            Console.WriteLine("Fetching created availability rule...");
+            var availabilityRule = client.GetAvailabilityRule(AvailabilityRuleId);
+
+            Console.WriteLine();
+            Console.WriteLine(availabilityRule.ToString());
+            Console.WriteLine();
+
+
+            Console.WriteLine("Fetching all availability rules...");
+            var availabilityRules = client.GetAvailabilityRules();
+
+            Console.WriteLine();
+
+            foreach (var rule in availabilityRules)
+            {
+                Console.WriteLine(rule.ToString());
+            }
+
+            Console.WriteLine();
+
+            Console.WriteLine("Press enter to delete the example rule...");
+            Console.ReadLine();
+
+            client.DeleteAvailabilityRule(AvailabilityRuleId);
+            Console.WriteLine("Availability rule deleted");
             Console.WriteLine();
 
             Console.WriteLine("Press enter to continue...");

--- a/src/Cronofy.Example/Program.cs
+++ b/src/Cronofy.Example/Program.cs
@@ -268,28 +268,28 @@
 
             const string AvailabilityRuleId = "CSharpExampleAvailabilityRule";
 
-            client.UpsertAvailabilityRule(new Requests.UpsertAvailabilityRuleRequest
+            client.UpsertAvailabilityRule(new AvailabilityRule
             {
                 AvailabilityRuleId = AvailabilityRuleId,
                 TimeZoneId = "America/Chicago",
                 CalendarIds = new[] { calendarId },
                 WeeklyPeriods = new[]
                 {
-                    new Requests.UpsertAvailabilityRuleRequest.WeeklyPeriod
+                    new AvailabilityRule.WeeklyPeriod
                     {
-                        Day = "monday",
+                        Day = DayOfWeek.Monday,
                         StartTime = "09:30",
                         EndTime = "12:30",
                     },
-                    new Requests.UpsertAvailabilityRuleRequest.WeeklyPeriod
+                    new AvailabilityRule.WeeklyPeriod
                     {
-                        Day = "monday",
+                        Day = DayOfWeek.Monday,
                         StartTime = "14:00",
                         EndTime = "17:00",
                     },
-                    new Requests.UpsertAvailabilityRuleRequest.WeeklyPeriod
+                    new AvailabilityRule.WeeklyPeriod
                     {
-                        Day = "wednesday",
+                        Day = DayOfWeek.Wednesday,
                         StartTime = "09:30",
                         EndTime = "12:30",
                     },
@@ -305,7 +305,6 @@
             Console.WriteLine();
             Console.WriteLine(availabilityRule.ToString());
             Console.WriteLine();
-
 
             Console.WriteLine("Fetching all availability rules...");
             var availabilityRules = client.GetAvailabilityRules();

--- a/src/Cronofy/AvailabilityRule.cs
+++ b/src/Cronofy/AvailabilityRule.cs
@@ -79,7 +79,7 @@ namespace Cronofy
         {
             return this.AvailabilityRuleId == other.AvailabilityRuleId &&
                 this.TimeZoneId == other.TimeZoneId &&
-                this.CalendarIds.SequenceEqual(other.CalendarIds) &&
+                ((this.CalendarIds == null && other.CalendarIds == null) || (this.CalendarIds != null && other.CalendarIds != null && this.CalendarIds.SequenceEqual(other.CalendarIds))) &&
                 this.WeeklyPeriods.SequenceEqual(other.WeeklyPeriods);
         }
 

--- a/src/Cronofy/AvailabilityRule.cs
+++ b/src/Cronofy/AvailabilityRule.cs
@@ -92,7 +92,7 @@ namespace Cronofy
                 this.AvailabilityRuleId,
                 this.TimeZoneId,
                 this.CalendarIds,
-                this.WeeklyPeriods);
+                string.Join(", ", this.WeeklyPeriods.Select(weeklyPeriod => weeklyPeriod.ToString())));
         }
 
         /// <summary>

--- a/src/Cronofy/AvailabilityRule.cs
+++ b/src/Cronofy/AvailabilityRule.cs
@@ -87,11 +87,11 @@ namespace Cronofy
         public override string ToString()
         {
             return string.Format(
-                "<{0} AvailabilityRuleId={1}, TimeZoneId={2}, CalendarIds={3}, WeeklyPeriods={4}>",
+                "<{0} AvailabilityRuleId={1}, TimeZoneId={2}, CalendarIds={3}, WeeklyPeriods=[{4}]>",
                 this.GetType(),
                 this.AvailabilityRuleId,
                 this.TimeZoneId,
-                this.CalendarIds,
+                this.CalendarIds == null ? "null" : string.Format("[{0}]", string.Join(", ", this.CalendarIds)),
                 string.Join(", ", this.WeeklyPeriods.Select(weeklyPeriod => weeklyPeriod.ToString())));
         }
 

--- a/src/Cronofy/AvailabilityRule.cs
+++ b/src/Cronofy/AvailabilityRule.cs
@@ -1,0 +1,181 @@
+namespace Cronofy
+{
+    using System;
+    using System.Linq;
+
+    /// <summary>
+    /// Class for representing an availability rule.
+    /// </summary>
+    public sealed class AvailabilityRule
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier of the availability rule.
+        /// </summary>
+        /// <value>
+        /// The unique identifier of the availability rule.
+        /// </value>
+        public string AvailabilityRuleId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time zone for which the availability rule start and end times are represented in.
+        /// </summary>
+        /// <value>
+        /// The time zone for which the availability rule start and end times are represented in.
+        /// </value>
+        public string TimeZoneId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the calendars that should impact the user's availability.
+        /// </summary>
+        /// <value>
+        /// The calendars that should impact the user's availability.
+        /// </value>
+        public string[] CalendarIds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the weekly recurring periods for the availability rule.
+        /// </summary>
+        /// <value>
+        /// The weekly recurring periods for the availability rule.
+        /// </value>
+        public WeeklyPeriod[] WeeklyPeriods { get; set; }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return this.AvailabilityRuleId.GetHashCode();
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj is AvailabilityRule && this.Equals((AvailabilityRule)obj);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="AvailabilityRule"/>
+        /// is equal to the current <see cref="AvailabilityRule"/>.
+        /// </summary>
+        /// <param name="other">
+        /// The <see cref="AvailabilityRule"/> to compare with the current
+        /// <see cref="AvailabilityRule"/>.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if the specified <see cref="AvailabilityRule"/> is
+        /// equal to the current <see cref="AvailabilityRule"/>; otherwise,
+        /// <c>false</c>.
+        /// </returns>
+        public bool Equals(AvailabilityRule other)
+        {
+            return this.AvailabilityRuleId == other.AvailabilityRuleId &&
+                this.TimeZoneId == other.TimeZoneId &&
+                this.CalendarIds.SequenceEqual(other.CalendarIds) &&
+                this.WeeklyPeriods.SequenceEqual(other.WeeklyPeriods);
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return string.Format(
+                "<{0} AvailabilityRuleId={1}, TimeZoneId={2}, CalendarIds={3}, WeeklyPeriods={4}>",
+                this.GetType(),
+                this.AvailabilityRuleId,
+                this.TimeZoneId,
+                this.CalendarIds,
+                this.WeeklyPeriods);
+        }
+
+        /// <summary>
+        /// Class to represent a weekly period.
+        /// </summary>
+        public class WeeklyPeriod
+        {
+            /// <summary>
+            /// Gets or sets the week day the period applies to.
+            /// </summary>
+            /// <value>
+            /// The week day the period applies to.
+            /// </value>
+            public string Day { get; set; }
+
+            /// <summary>
+            /// Gets or sets the time of day the period should start.
+            /// </summary>
+            /// <value>
+            /// The time of day the period should start.
+            /// </value>
+            public string StartTime { get; set; }
+
+            /// <summary>
+            /// Gets or sets the time of day the period should end.
+            /// </summary>
+            /// <value>
+            /// The time of day the period should end.
+            /// </value>
+            public string EndTime { get; set; }
+
+            /// <inheritdoc />
+            public override int GetHashCode()
+            {
+                return this.Day.GetHashCode() ^ this.StartTime.GetHashCode() ^ this.EndTime.GetHashCode();
+            }
+
+            /// <inheritdoc/>
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj))
+                {
+                    return false;
+                }
+
+                if (ReferenceEquals(this, obj))
+                {
+                    return true;
+                }
+
+                return obj is WeeklyPeriod && this.Equals((WeeklyPeriod)obj);
+            }
+
+            /// <summary>
+            /// Determines whether the specified <see cref="WeeklyPeriod"/>
+            /// is equal to the current <see cref="WeeklyPeriod"/>.
+            /// </summary>
+            /// <param name="other">
+            /// The <see cref="WeeklyPeriod"/> to compare with the current
+            /// <see cref="WeeklyPeriod"/>.
+            /// </param>
+            /// <returns>
+            /// <c>true</c> if the specified <see cref="WeeklyPeriod"/> is
+            /// equal to the current <see cref="WeeklyPeriod"/>; otherwise,
+            /// <c>false</c>.
+            /// </returns>
+            public bool Equals(WeeklyPeriod other)
+            {
+                return this.Day == other.Day &&
+                    this.StartTime == other.StartTime &&
+                    this.EndTime == other.EndTime;
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return string.Format(
+                    "<{0} Day={1}, StartTime={2}, EndTime={3}>",
+                    this.GetType(),
+                    this.Day,
+                    this.StartTime,
+                    this.EndTime);
+            }
+        }
+    }
+}

--- a/src/Cronofy/AvailabilityRule.cs
+++ b/src/Cronofy/AvailabilityRule.cs
@@ -106,7 +106,7 @@ namespace Cronofy
             /// <value>
             /// The week day the period applies to.
             /// </value>
-            public string Day { get; set; }
+            public DayOfWeek Day { get; set; }
 
             /// <summary>
             /// Gets or sets the time of day the period should start.

--- a/src/Cronofy/CronofyAccountClient.cs
+++ b/src/Cronofy/CronofyAccountClient.cs
@@ -560,6 +560,67 @@ namespace Cronofy
             return response.AuthorizationRequest.Url;
         }
 
+        /// <inheritdoc/>
+        public AvailabilityRule GetAvailabilityRule(string availabilityRuleId)
+        {
+            Preconditions.NotEmpty("availabilityRuleId", availabilityRuleId);
+
+            var request = new HttpRequest();
+
+            request.Method = "GET";
+            request.Url = string.Format(this.UrlProvider.AvailabilityRuleUrl, availabilityRuleId);
+            request.AddOAuthAuthorization(this.AccessToken);
+
+            var response = this.HttpClient.GetJsonResponse<AvailabilityRuleResponse>(request);
+
+            return response.ToAvailabilityRule();
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<AvailabilityRule> GetAvailabilityRules()
+        {
+            var request = new HttpRequest();
+
+            request.Method = "GET";
+            request.Url = this.UrlProvider.AvailabilityRulesUrl;
+            request.AddOAuthAuthorization(this.AccessToken);
+
+            var response = this.HttpClient.GetJsonResponse<ListAvailabilityRulesResponse>(request);
+
+            return response.AvailabilityRules.Select(ap => ap.ToAvailabilityRule());
+        }
+
+        /// <inheritdoc/>
+        public AvailabilityRule UpsertAvailabilityRule(UpsertAvailabilityRuleRequest upsertAvailabilityRuleRequest)
+        {
+            Preconditions.NotNull("upsertAvailabilityRuleRequest", upsertAvailabilityRuleRequest);
+
+            var request = new HttpRequest();
+
+            request.Method = "POST";
+            request.Url = this.UrlProvider.AvailabilityRulesUrl;
+            request.AddOAuthAuthorization(this.AccessToken);
+            request.SetJsonBody(upsertAvailabilityRuleRequest);
+
+            var response = this.HttpClient.GetJsonResponse<AvailabilityRuleResponse>(request);
+
+            return response.ToAvailabilityRule();
+        }
+
+        /// <inheritdoc/>
+        public void DeleteAvailabilityRule(string availabilityRuleId)
+        {
+            Preconditions.NotEmpty("availabilityRuleId", availabilityRuleId);
+
+            var request = new HttpRequest();
+
+            request.Method = "DELETE";
+            request.Url = string.Format(this.UrlProvider.AvailabilityRuleUrl, availabilityRuleId);
+            request.AddOAuthAuthorization(this.AccessToken);
+
+            this.HttpClient.GetValidResponse(request);
+        }
+
         /// <summary>
         /// Creates a calendar.
         /// </summary>

--- a/src/Cronofy/CronofyAccountClient.cs
+++ b/src/Cronofy/CronofyAccountClient.cs
@@ -571,7 +571,7 @@ namespace Cronofy
             request.Url = string.Format(this.UrlProvider.AvailabilityRuleUrl, availabilityRuleId);
             request.AddOAuthAuthorization(this.AccessToken);
 
-            var response = this.HttpClient.GetJsonResponse<GetAvailabilityRulesResponse>(request);
+            var response = this.HttpClient.GetJsonResponse<GetAvailabilityRuleResponse>(request);
 
             return response.AvailabilityRule.ToAvailabilityRule();
         }
@@ -602,7 +602,7 @@ namespace Cronofy
             request.AddOAuthAuthorization(this.AccessToken);
             request.SetJsonBody(upsertAvailabilityRuleRequest);
 
-            var response = this.HttpClient.GetJsonResponse<UpsertAvailabilityRulesResponse>(request);
+            var response = this.HttpClient.GetJsonResponse<UpsertAvailabilityRuleResponse>(request);
 
             return response.AvailabilityRule.ToAvailabilityRule();
         }

--- a/src/Cronofy/CronofyAccountClient.cs
+++ b/src/Cronofy/CronofyAccountClient.cs
@@ -571,9 +571,9 @@ namespace Cronofy
             request.Url = string.Format(this.UrlProvider.AvailabilityRuleUrl, availabilityRuleId);
             request.AddOAuthAuthorization(this.AccessToken);
 
-            var response = this.HttpClient.GetJsonResponse<AvailabilityRuleResponse>(request);
+            var response = this.HttpClient.GetJsonResponse<GetAvailabilityRulesResponse>(request);
 
-            return response.ToAvailabilityRule();
+            return response.AvailabilityRule.ToAvailabilityRule();
         }
 
         /// <inheritdoc/>
@@ -602,9 +602,9 @@ namespace Cronofy
             request.AddOAuthAuthorization(this.AccessToken);
             request.SetJsonBody(upsertAvailabilityRuleRequest);
 
-            var response = this.HttpClient.GetJsonResponse<AvailabilityRuleResponse>(request);
+            var response = this.HttpClient.GetJsonResponse<UpsertAvailabilityRulesResponse>(request);
 
-            return response.ToAvailabilityRule();
+            return response.AvailabilityRule.ToAvailabilityRule();
         }
 
         /// <inheritdoc/>

--- a/src/Cronofy/CronofyAccountClient.cs
+++ b/src/Cronofy/CronofyAccountClient.cs
@@ -563,7 +563,7 @@ namespace Cronofy
         /// <inheritdoc/>
         public AvailabilityRule GetAvailabilityRule(string availabilityRuleId)
         {
-            Preconditions.NotEmpty("availabilityRuleId", availabilityRuleId);
+            Preconditions.NotEmpty(nameof(availabilityRuleId), availabilityRuleId);
 
             var request = new HttpRequest();
 
@@ -591,15 +591,17 @@ namespace Cronofy
         }
 
         /// <inheritdoc/>
-        public AvailabilityRule UpsertAvailabilityRule(UpsertAvailabilityRuleRequest upsertAvailabilityRuleRequest)
+        public AvailabilityRule UpsertAvailabilityRule(AvailabilityRule availabilityRule)
         {
-            Preconditions.NotNull("upsertAvailabilityRuleRequest", upsertAvailabilityRuleRequest);
+            Preconditions.NotNull(nameof(availabilityRule), availabilityRule);
 
             var request = new HttpRequest();
 
             request.Method = "POST";
             request.Url = this.UrlProvider.AvailabilityRulesUrl;
             request.AddOAuthAuthorization(this.AccessToken);
+
+            var upsertAvailabilityRuleRequest = UpsertAvailabilityRuleRequest.FromAvailabilityRule(availabilityRule);
             request.SetJsonBody(upsertAvailabilityRuleRequest);
 
             var response = this.HttpClient.GetJsonResponse<UpsertAvailabilityRuleResponse>(request);
@@ -610,7 +612,7 @@ namespace Cronofy
         /// <inheritdoc/>
         public void DeleteAvailabilityRule(string availabilityRuleId)
         {
-            Preconditions.NotEmpty("availabilityRuleId", availabilityRuleId);
+            Preconditions.NotEmpty(nameof(availabilityRuleId), availabilityRuleId);
 
             var request = new HttpRequest();
 

--- a/src/Cronofy/ICronofyAccountClient.cs
+++ b/src/Cronofy/ICronofyAccountClient.cs
@@ -588,17 +588,17 @@
         /// <summary>
         /// Creates or updates an availability rule.
         /// </summary>
-        /// <param name="upsertAvailabilityRuleRequest">
-        /// The parameters for the request, must not be null.
+        /// <param name="availabilityRule">
+        /// The availability rule to upsert, must not be null.
         /// </param>
         /// <returns>The created or updated availability rule.</returns>
         /// <exception cref="ArgumentException">
-        /// Thrown if <paramref name="upsertAvailabilityRuleRequest"/> is null.
+        /// Thrown if <paramref name="availabilityRule"/> is null.
         /// </exception>
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
-        AvailabilityRule UpsertAvailabilityRule(UpsertAvailabilityRuleRequest upsertAvailabilityRuleRequest);
+        AvailabilityRule UpsertAvailabilityRule(AvailabilityRule availabilityRule);
 
         /// <summary>
         /// Deletes an availability rule for the authenticated account.

--- a/src/Cronofy/ICronofyAccountClient.cs
+++ b/src/Cronofy/ICronofyAccountClient.cs
@@ -554,11 +554,64 @@
         /// </param>
         /// <returns>The URL which the end-user should visit.</returns>
         /// <exception cref="ArgumentException">
-        /// Thrown if <paramref name="conferencingServiceAuthorizationRequest"/> if null, or it doesn't contain a Redirect URI.
+        /// Thrown if <paramref name="conferencingServiceAuthorizationRequest"/> is null, or it doesn't contain a Redirect URI.
         /// </exception>
         /// <exception cref="CronofyException">
         /// Thrown if an error is encountered whilst making the request.
         /// </exception>
         string GetConferencingServiceAuthorizationUrl(ConferencingServiceAuthorizationRequest conferencingServiceAuthorizationRequest);
+
+        /// <summary>
+        /// Reads a single availability rule.
+        /// </summary>
+        /// <param name="availabilityRuleId">
+        /// The unique identifier of the availability rule.
+        /// </param>
+        /// <returns>The availability rule.</returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="availabilityRuleId"/> is null, or empty.
+        /// </exception>
+        /// <exception cref="CronofyException">
+        /// Thrown if an error is encountered whilst making the request.
+        /// </exception>
+        AvailabilityRule GetAvailabilityRule(string availabilityRuleId);
+
+        /// <summary>
+        /// Retrieves all availability rules saved against an account.
+        /// </summary>
+        /// <returns>The list of all availability rules.</returns>
+        /// <exception cref="CronofyException">
+        /// Thrown if an error is encountered whilst making the request.
+        /// </exception>
+        IEnumerable<AvailabilityRule> GetAvailabilityRules();
+
+        /// <summary>
+        /// Creates or updates an availability rule.
+        /// </summary>
+        /// <param name="upsertAvailabilityRuleRequest">
+        /// The parameters for the request, must not be null.
+        /// </param>
+        /// <returns>The created or updated availability rule.</returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="upsertAvailabilityRuleRequest"/> is null.
+        /// </exception>
+        /// <exception cref="CronofyException">
+        /// Thrown if an error is encountered whilst making the request.
+        /// </exception>
+        AvailabilityRule UpsertAvailabilityRule(UpsertAvailabilityRuleRequest upsertAvailabilityRuleRequest);
+
+        /// <summary>
+        /// Deletes an availability rule for the authenticated account.
+        /// </summary>
+        /// <param name="availabilityRuleId">
+        /// The unique identifier of the availability rule.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="availabilityRuleId"/> is null, or empty.
+        /// </exception>
+        /// <exception cref="CronofyException">
+        /// Thrown if an error is encountered whilst making the request.
+        /// </exception>
+        void DeleteAvailabilityRule(string availabilityRuleId);
     }
 }

--- a/src/Cronofy/Requests/UpsertAvailabilityRuleRequest.cs
+++ b/src/Cronofy/Requests/UpsertAvailabilityRuleRequest.cs
@@ -1,0 +1,82 @@
+namespace Cronofy.Requests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Class for the serialization of an upsert availability rule request.
+    /// </summary>
+    public sealed class UpsertAvailabilityRuleRequest
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier of the availability rule.
+        /// </summary>
+        /// <value>
+        /// The unique identifier of the availability rule.
+        /// </value>
+        [JsonProperty("availability_rule_id")]
+        public string AvailabilityRuleId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time zone for which the availability rule start and end times are represented in.
+        /// </summary>
+        /// <value>
+        /// The time zone for which the availability rule start and end times are represented in.
+        /// </value>
+        [JsonProperty("tzid")]
+        public string TimeZoneId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the calendars that should impact the user's availability.
+        /// </summary>
+        /// <value>
+        /// The calendars that should impact the user's availability.
+        /// </value>
+        [JsonProperty("calendar_ids")]
+        public IEnumerable<string> CalendarIds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the weekly recurring periods for the availability rule.
+        /// </summary>
+        /// <value>
+        /// The weekly recurring periods for the availability rule.
+        /// </value>
+        [JsonProperty("weekly_periods")]
+        public IEnumerable<WeeklyPeriod> WeeklyPeriods { get; set; }
+
+        /// <summary>
+        /// Class for the serialization of a weekly period within an availability rule.
+        /// </summary>
+        public sealed class WeeklyPeriod
+        {
+            /// <summary>
+            /// Gets or sets the week day the period applies to.
+            /// </summary>
+            /// <value>
+            /// The week day the period applies to.
+            /// </value>
+            [JsonProperty("day")]
+            public string Day { get; set; }
+
+            /// <summary>
+            /// Gets or sets the time of day the period should start.
+            /// </summary>
+            /// <value>
+            /// The time of day the period should start.
+            /// </value>
+            [JsonProperty("start_time")]
+            public string StartTime { get; set; }
+
+            /// <summary>
+            /// Gets or sets the time of day the period should end.
+            /// </summary>
+            /// <value>
+            /// The time of day the period should end.
+            /// </value>
+            [JsonProperty("end_time")]
+            public string EndTime { get; set; }
+        }
+    }
+}

--- a/src/Cronofy/Requests/UpsertAvailabilityRuleRequest.cs
+++ b/src/Cronofy/Requests/UpsertAvailabilityRuleRequest.cs
@@ -47,6 +47,22 @@ namespace Cronofy.Requests
         public IEnumerable<WeeklyPeriod> WeeklyPeriods { get; set; }
 
         /// <summary>
+        /// Creates an upsert request from an existing availability rule.
+        /// </summary>
+        /// <param name="availabilityRule">Availability rule to create this upsert request from.</param>
+        /// <returns>An upsert request for the given rule.</returns>
+        public static UpsertAvailabilityRuleRequest FromAvailabilityRule(AvailabilityRule availabilityRule)
+        {
+            return new UpsertAvailabilityRuleRequest
+            {
+                AvailabilityRuleId = availabilityRule.AvailabilityRuleId,
+                TimeZoneId = availabilityRule.TimeZoneId,
+                CalendarIds = availabilityRule.CalendarIds.ToArray(),
+                WeeklyPeriods = availabilityRule.WeeklyPeriods.Select(WeeklyPeriod.FromWeeklyPeriod).ToArray(),
+            };
+        }
+
+        /// <summary>
         /// Class for the serialization of a weekly period within an availability rule.
         /// </summary>
         public sealed class WeeklyPeriod
@@ -77,6 +93,49 @@ namespace Cronofy.Requests
             /// </value>
             [JsonProperty("end_time")]
             public string EndTime { get; set; }
+
+            /// <summary>
+            /// Creates an upset weekly period request from a given weekly period.
+            /// </summary>
+            /// <param name="weeklyPeriod">The weekly period to copy from.</param>
+            /// <returns>The weekly period upsert request.</returns>
+            public static WeeklyPeriod FromWeeklyPeriod(AvailabilityRule.WeeklyPeriod weeklyPeriod)
+            {
+                return new WeeklyPeriod
+                {
+                    Day = ToDayString(weeklyPeriod.Day),
+                    StartTime = weeklyPeriod.StartTime,
+                    EndTime = weeklyPeriod.EndTime,
+                };
+            }
+
+            /// <summary>
+            /// Converts a day of the week to its string representation.
+            /// </summary>
+            /// <param name="day">The day of the week.</param>
+            /// <returns>The string representation of the day of the week.</returns>
+            private static string ToDayString(DayOfWeek day)
+            {
+                switch (day)
+                {
+                    case DayOfWeek.Monday:
+                        return "monday";
+                    case DayOfWeek.Tuesday:
+                        return "tuesday";
+                    case DayOfWeek.Wednesday:
+                        return "wednesday";
+                    case DayOfWeek.Thursday:
+                        return "thursday";
+                    case DayOfWeek.Friday:
+                        return "friday";
+                    case DayOfWeek.Saturday:
+                        return "saturday";
+                    case DayOfWeek.Sunday:
+                        return "sunday";
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(day), "Unexpected day");
+                }
+            }
         }
     }
 }

--- a/src/Cronofy/Requests/UpsertAvailabilityRuleRequest.cs
+++ b/src/Cronofy/Requests/UpsertAvailabilityRuleRequest.cs
@@ -57,7 +57,7 @@ namespace Cronofy.Requests
             {
                 AvailabilityRuleId = availabilityRule.AvailabilityRuleId,
                 TimeZoneId = availabilityRule.TimeZoneId,
-                CalendarIds = availabilityRule.CalendarIds.ToArray(),
+                CalendarIds = availabilityRule.CalendarIds?.ToArray(),
                 WeeklyPeriods = availabilityRule.WeeklyPeriods.Select(WeeklyPeriod.FromWeeklyPeriod).ToArray(),
             };
         }

--- a/src/Cronofy/Responses/AvailabilityRuleResponse.cs
+++ b/src/Cronofy/Responses/AvailabilityRuleResponse.cs
@@ -58,7 +58,7 @@ namespace Cronofy.Responses
             {
                 AvailabilityRuleId = this.AvailabilityRuleId,
                 TimeZoneId = this.TimeZoneId,
-                CalendarIds = this.CalendarIds.ToArray(),
+                CalendarIds = this.CalendarIds?.ToArray(),
                 WeeklyPeriods = this.WeeklyPeriods.Select(weeklyPeriod => weeklyPeriod.ToWeeklyPeriod()).ToArray(),
             };
         }

--- a/src/Cronofy/Responses/AvailabilityRuleResponse.cs
+++ b/src/Cronofy/Responses/AvailabilityRuleResponse.cs
@@ -1,0 +1,115 @@
+namespace Cronofy.Responses
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Class for the deserialization of a read availability rule response.
+    /// </summary>
+    internal sealed class AvailabilityRuleResponse
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier of the availability rule.
+        /// </summary>
+        /// <value>
+        /// The unique identifier of the availability rule.
+        /// </value>
+        [JsonProperty("availability_rule_id")]
+        public string AvailabilityRuleId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time zone for which the availability rule start and end times are represented in.
+        /// </summary>
+        /// <value>
+        /// The time zone for which the availability rule start and end times are represented in.
+        /// </value>
+        [JsonProperty("tzid")]
+        public string TimeZoneId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the calendars that should impact the user's availability.
+        /// </summary>
+        /// <value>
+        /// The calendars that should impact the user's availability.
+        /// </value>
+        [JsonProperty("calendar_ids")]
+        public IEnumerable<string> CalendarIds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the weekly recurring periods for the availability rule.
+        /// </summary>
+        /// <value>
+        /// The weekly recurring periods for the availability rule.
+        /// </value>
+        [JsonProperty("weekly_periods")]
+        public IEnumerable<WeeklyPeriod> WeeklyPeriods { get; set; }
+
+        /// <summary>
+        /// Converts the response to an <see cref="AvailabilityRule"/>.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="AvailabilityRule"/>.
+        /// </returns>
+        public AvailabilityRule ToAvailabilityRule()
+        {
+            return new AvailabilityRule
+            {
+                AvailabilityRuleId = this.AvailabilityRuleId,
+                TimeZoneId = this.TimeZoneId,
+                CalendarIds = this.CalendarIds.ToArray(),
+                WeeklyPeriods = this.WeeklyPeriods.Select(weeklyPeriod => weeklyPeriod.ToWeeklyPeriod()).ToArray(),
+            };
+        }
+
+        /// <summary>
+        /// Class for the deserialization of a weekly period within an availability rule.
+        /// </summary>
+        internal sealed class WeeklyPeriod
+        {
+            /// <summary>
+            /// Gets or sets the week day the period applies to.
+            /// </summary>
+            /// <value>
+            /// The week day the period applies to.
+            /// </value>
+            [JsonProperty("day")]
+            public string Day { get; set; }
+
+            /// <summary>
+            /// Gets or sets the time of day the period should start.
+            /// </summary>
+            /// <value>
+            /// The time of day the period should start.
+            /// </value>
+            [JsonProperty("start_time")]
+            public string StartTime { get; set; }
+
+            /// <summary>
+            /// Gets or sets the time of day the period should end.
+            /// </summary>
+            /// <value>
+            /// The time of day the period should end.
+            /// </value>
+            [JsonProperty("end_time")]
+            public string EndTime { get; set; }
+
+            /// <summary>
+            /// Converts the response to an <see cref="AvailabilityRule.WeeklyPeriod"/>.
+            /// </summary>
+            /// <returns>
+            /// An <see cref="AvailabilityRule"/>.
+            /// </returns>
+            public AvailabilityRule.WeeklyPeriod ToWeeklyPeriod()
+            {
+                return new AvailabilityRule.WeeklyPeriod
+                {
+                    Day = this.Day,
+                    StartTime = this.StartTime,
+                    EndTime = this.EndTime,
+                };
+            }
+        }
+    }
+}

--- a/src/Cronofy/Responses/AvailabilityRuleResponse.cs
+++ b/src/Cronofy/Responses/AvailabilityRuleResponse.cs
@@ -105,10 +105,38 @@ namespace Cronofy.Responses
             {
                 return new AvailabilityRule.WeeklyPeriod
                 {
-                    Day = this.Day,
+                    Day = ToDayOfWeek(this.Day),
                     StartTime = this.StartTime,
                     EndTime = this.EndTime,
                 };
+            }
+
+            /// <summary>
+            /// Converts a day string to a day of the week representation.
+            /// </summary>
+            /// <param name="day">The string representation of the day of the week.</param>
+            /// <returns>The day of the week represented by the string.</returns>
+            private static DayOfWeek ToDayOfWeek(string day)
+            {
+                switch (day)
+                {
+                    case "monday":
+                        return DayOfWeek.Monday;
+                    case "tuesday":
+                        return DayOfWeek.Tuesday;
+                    case "wednesday":
+                        return DayOfWeek.Wednesday;
+                    case "thursday":
+                        return DayOfWeek.Thursday;
+                    case "friday":
+                        return DayOfWeek.Friday;
+                    case "saturday":
+                        return DayOfWeek.Saturday;
+                    case "sunday":
+                        return DayOfWeek.Sunday;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(day), "Unexpected day");
+                }
             }
         }
     }

--- a/src/Cronofy/Responses/GetAvailabilityRuleResponse.cs
+++ b/src/Cronofy/Responses/GetAvailabilityRuleResponse.cs
@@ -1,0 +1,21 @@
+namespace Cronofy.Responses
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Class for the deserialization of a get availability rule response.
+    /// </summary>
+    internal sealed class GetAvailabilityRulesResponse
+    {
+        /// <summary>
+        /// Gets or sets the availability rule.
+        /// </summary>
+        /// <value>
+        /// The availability rule.
+        /// </value>
+        [JsonProperty("availability_rule")]
+        public AvailabilityRuleResponse AvailabilityRule { get; set; }
+    }
+}

--- a/src/Cronofy/Responses/GetAvailabilityRuleResponse.cs
+++ b/src/Cronofy/Responses/GetAvailabilityRuleResponse.cs
@@ -7,7 +7,7 @@ namespace Cronofy.Responses
     /// <summary>
     /// Class for the deserialization of a get availability rule response.
     /// </summary>
-    internal sealed class GetAvailabilityRulesResponse
+    internal sealed class GetAvailabilityRuleResponse
     {
         /// <summary>
         /// Gets or sets the availability rule.

--- a/src/Cronofy/Responses/ListAvailabilityRulesResponse.cs
+++ b/src/Cronofy/Responses/ListAvailabilityRulesResponse.cs
@@ -1,0 +1,21 @@
+namespace Cronofy.Responses
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Class for the deserialization of a list availability rules response.
+    /// </summary>
+    internal sealed class ListAvailabilityRulesResponse
+    {
+        /// <summary>
+        /// Gets or sets the weekly recurring periods for the availability rule.
+        /// </summary>
+        /// <value>
+        /// The weekly recurring periods for the availability rule.
+        /// </value>
+        [JsonProperty("availability_rules")]
+        public IEnumerable<AvailabilityRuleResponse> AvailabilityRules { get; set; }
+    }
+}

--- a/src/Cronofy/Responses/ListAvailabilityRulesResponse.cs
+++ b/src/Cronofy/Responses/ListAvailabilityRulesResponse.cs
@@ -10,10 +10,10 @@ namespace Cronofy.Responses
     internal sealed class ListAvailabilityRulesResponse
     {
         /// <summary>
-        /// Gets or sets the weekly recurring periods for the availability rule.
+        /// Gets or sets the list of discovered availability rules.
         /// </summary>
         /// <value>
-        /// The weekly recurring periods for the availability rule.
+        /// The list of discovered availability rules.
         /// </value>
         [JsonProperty("availability_rules")]
         public IEnumerable<AvailabilityRuleResponse> AvailabilityRules { get; set; }

--- a/src/Cronofy/Responses/UpsertAvailabilityRuleResponse.cs
+++ b/src/Cronofy/Responses/UpsertAvailabilityRuleResponse.cs
@@ -1,0 +1,21 @@
+namespace Cronofy.Responses
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Class for the deserialization of an upsert availability rules response.
+    /// </summary>
+    internal sealed class UpsertAvailabilityRulesResponse
+    {
+        /// <summary>
+        /// Gets or sets the created or updated availability rule.
+        /// </summary>
+        /// <value>
+        /// The created or updated availability rule.
+        /// </value>
+        [JsonProperty("availability_rule")]
+        public AvailabilityRuleResponse AvailabilityRule { get; set; }
+    }
+}

--- a/src/Cronofy/Responses/UpsertAvailabilityRuleResponse.cs
+++ b/src/Cronofy/Responses/UpsertAvailabilityRuleResponse.cs
@@ -7,7 +7,7 @@ namespace Cronofy.Responses
     /// <summary>
     /// Class for the deserialization of an upsert availability rules response.
     /// </summary>
-    internal sealed class UpsertAvailabilityRulesResponse
+    internal sealed class UpsertAvailabilityRuleResponse
     {
         /// <summary>
         /// Gets or sets the created or updated availability rule.

--- a/src/Cronofy/UrlProvider.cs
+++ b/src/Cronofy/UrlProvider.cs
@@ -176,6 +176,16 @@ namespace Cronofy
         private const string AttachmentsUrlFormat = "https://api{0}.cronofy.com/v1/attachments";
 
         /// <summary>
+        /// The URL of the Availability Rule endpoint.
+        /// </summary>
+        private const string AvailabilityRulesUrlFormat = "https://api{0}.cronofy.com/v1/availability_rules";
+
+        /// <summary>
+        /// The URL of the Availability Rule endpoint for a specific rule.
+        /// </summary>
+        private const string AvailabilityRuleUrlFormat = "https://api{0}.cronofy.com/v1/availability_rules/{{0}}";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="UrlProvider"/> class.
         /// </summary>
         /// <param name="dataCenter">
@@ -224,6 +234,8 @@ namespace Cronofy
             this.ElementTokensUrl = string.Format(ElementTokensUrlFormat, suffix);
             this.ConferencingServiceAuthorizationUrl = string.Format(ConferencingServiceAuthorizationUrlFormat, suffix);
             this.AttachmentsUrl = string.Format(AttachmentsUrlFormat, suffix);
+            this.AvailabilityRulesUrl = string.Format(AvailabilityRulesUrlFormat, suffix);
+            this.AvailabilityRuleUrl = string.Format(AvailabilityRuleUrlFormat, suffix);
         }
 
         /// <summary>
@@ -232,11 +244,7 @@ namespace Cronofy
         /// <value>
         /// The authorization URL.
         /// </value>
-        public string AuthorizationUrl
-        {
-            get;
-            private set;
-        }
+        public string AuthorizationUrl { get; private set; }
 
         /// <summary>
         /// Gets the Enterprise Connect authorization URL.
@@ -244,11 +252,7 @@ namespace Cronofy
         /// <value>
         /// The Enterprise Connect authorization URL.
         /// </value>
-        public string EnterpriseConnectAuthorizationUrl
-        {
-            get;
-            private set;
-        }
+        public string EnterpriseConnectAuthorizationUrl { get; private set; }
 
         /// <summary>
         /// Gets the OAuth token URL.
@@ -256,11 +260,7 @@ namespace Cronofy
         /// <value>
         /// The OAuth token URL.
         /// </value>
-        public string TokenUrl
-        {
-            get;
-            private set;
-        }
+        public string TokenUrl { get; private set; }
 
         /// <summary>
         /// Gets the OAuth token revocation URL.
@@ -268,11 +268,7 @@ namespace Cronofy
         /// <value>
         /// The OAuth token revocation URL.
         /// </value>
-        public string TokenRevocationUrl
-        {
-            get;
-            private set;
-        }
+        public string TokenRevocationUrl { get; private set; }
 
         /// <summary>
         /// Gets the userinfo URL.
@@ -280,11 +276,7 @@ namespace Cronofy
         /// <value>
         /// The userinfo URL.
         /// </value>
-        public string UserInfoUrl
-        {
-            get;
-            private set;
-        }
+        public string UserInfoUrl { get; private set; }
 
         /// <summary>
         /// Gets the resources URL.
@@ -292,11 +284,7 @@ namespace Cronofy
         /// <value>
         /// The resources URL.
         /// </value>
-        public string ResourcesUrl
-        {
-            get;
-            private set;
-        }
+        public string ResourcesUrl { get; private set; }
 
         /// <summary>
         /// Gets the authorize with service account URL.
@@ -304,11 +292,7 @@ namespace Cronofy
         /// <value>
         /// The authorize with service account URL.
         /// </value>
-        public string AuthorizeWithServiceAccountUrl
-        {
-            get;
-            private set;
-        }
+        public string AuthorizeWithServiceAccountUrl { get; private set; }
 
         /// <summary>
         /// Gets the account URL.
@@ -316,11 +300,7 @@ namespace Cronofy
         /// <value>
         /// The account URL.
         /// </value>
-        public string AccountUrl
-        {
-            get;
-            private set;
-        }
+        public string AccountUrl { get; private set; }
 
         /// <summary>
         /// Gets the profiles URL.
@@ -328,11 +308,7 @@ namespace Cronofy
         /// <value>
         /// The profiles URL.
         /// </value>
-        public string ProfilesUrl
-        {
-            get;
-            private set;
-        }
+        public string ProfilesUrl { get; private set; }
 
         /// <summary>
         /// Gets the calendars URL.
@@ -340,11 +316,7 @@ namespace Cronofy
         /// <value>
         /// The calendars URL.
         /// </value>
-        public string CalendarsUrl
-        {
-            get;
-            private set;
-        }
+        public string CalendarsUrl { get; private set; }
 
         /// <summary>
         /// Gets the free busy URL.
@@ -352,11 +324,7 @@ namespace Cronofy
         /// <value>
         /// The free busy URL.
         /// </value>
-        public string FreeBusyUrl
-        {
-            get;
-            private set;
-        }
+        public string FreeBusyUrl { get; private set; }
 
         /// <summary>
         /// Gets the events URL.
@@ -364,11 +332,7 @@ namespace Cronofy
         /// <value>
         /// The events URL.
         /// </value>
-        public string EventsUrl
-        {
-            get;
-            private set;
-        }
+        public string EventsUrl { get; private set; }
 
         /// <summary>
         /// Gets the managed event URL format.
@@ -376,11 +340,7 @@ namespace Cronofy
         /// <value>
         /// The managed event URL format.
         /// </value>
-        public string ManagedEventUrlFormat
-        {
-            get;
-            private set;
-        }
+        public string ManagedEventUrlFormat { get; private set; }
 
         /// <summary>
         /// Gets the participation status URL format.
@@ -388,11 +348,7 @@ namespace Cronofy
         /// <value>
         /// The participation status URL format.
         /// </value>
-        public string ParticipationStatusUrlFormat
-        {
-            get;
-            private set;
-        }
+        public string ParticipationStatusUrlFormat { get; private set; }
 
         /// <summary>
         /// Gets the channels URL.
@@ -400,11 +356,7 @@ namespace Cronofy
         /// <value>
         /// The channels URL.
         /// </value>
-        public string ChannelsUrl
-        {
-            get;
-            private set;
-        }
+        public string ChannelsUrl { get; private set; }
 
         /// <summary>
         /// Gets the channel URL format.
@@ -412,11 +364,7 @@ namespace Cronofy
         /// <value>
         /// The channel URL format.
         /// </value>
-        public string ChannelUrlFormat
-        {
-            get;
-            private set;
-        }
+        public string ChannelUrlFormat { get; private set; }
 
         /// <summary>
         /// Gets the permissions URL.
@@ -424,11 +372,7 @@ namespace Cronofy
         /// <value>
         /// The permissions URL.
         /// </value>
-        public string PermissionsUrl
-        {
-            get;
-            private set;
-        }
+        public string PermissionsUrl { get; private set; }
 
         /// <summary>
         /// Gets the availability URL.
@@ -436,11 +380,7 @@ namespace Cronofy
         /// <value>
         /// The availability URL.
         /// </value>
-        public string AvailabilityUrl
-        {
-            get;
-            private set;
-        }
+        public string AvailabilityUrl { get; private set; }
 
         /// <summary>
         /// Gets the add to calendar URL.
@@ -448,11 +388,7 @@ namespace Cronofy
         /// <value>
         /// The add to calendar URL.
         /// </value>
-        public string AddToCalendarUrl
-        {
-            get;
-            private set;
-        }
+        public string AddToCalendarUrl { get; private set; }
 
         /// <summary>
         /// Gets the real time scheduling URL.
@@ -460,11 +396,7 @@ namespace Cronofy
         /// <value>
         /// The real time scheduling URL.
         /// </value>
-        public string RealTimeSchedulingUrl
-        {
-            get;
-            private set;
-        }
+        public string RealTimeSchedulingUrl { get; private set; }
 
         /// <summary>
         /// Gets the real time scheduling by ID URL.
@@ -472,11 +404,7 @@ namespace Cronofy
         /// <value>
         /// The real time scheduling by ID URL.
         /// </value>
-        public string RealTimeSchedulingByIdUrl
-        {
-            get;
-            private set;
-        }
+        public string RealTimeSchedulingByIdUrl { get; private set; }
 
         /// <summary>
         /// Gets the real time scheduling disable URL format.
@@ -484,11 +412,7 @@ namespace Cronofy
         /// <value>
         /// The real time scheduling disable URL format.
         /// </value>
-        public string DisableRealTimeSchedulingUrlFormat
-        {
-            get;
-            private set;
-        }
+        public string DisableRealTimeSchedulingUrlFormat { get; private set; }
 
         /// <summary>
         /// Gets the link tokens URL.
@@ -496,11 +420,7 @@ namespace Cronofy
         /// <value>
         /// The link tokens URL.
         /// </value>
-        public string LinkTokensUrl
-        {
-            get;
-            private set;
-        }
+        public string LinkTokensUrl { get; private set; }
 
         /// <summary>
         /// Gets the revoke profile authorization URL format.
@@ -508,11 +428,7 @@ namespace Cronofy
         /// <value>
         /// The revoke profile authorization URL format.
         /// </value>
-        public string RevokeProfileAuthorizationUrlFormat
-        {
-            get;
-            private set;
-        }
+        public string RevokeProfileAuthorizationUrlFormat { get; private set; }
 
         /// <summary>
         /// Gets the Smart Invite URL.
@@ -526,11 +442,7 @@ namespace Cronofy
         /// <value>
         /// The batch request URL.
         /// </value>
-        public string BatchUrl
-        {
-            get;
-            private set;
-        }
+        public string BatchUrl { get; private set; }
 
         /// <summary>
         /// Gets the application calendars URL.
@@ -579,5 +491,17 @@ namespace Cronofy
         /// </summary>
         /// <value>The attachments URL.</value>
         public string AttachmentsUrl { get; private set; }
+
+        /// <summary>
+        /// Gets the Availability Rule URL.
+        /// </summary>
+        /// <value>The Availability Rule URL.</value>
+        public string AvailabilityRulesUrl { get; private set; }
+
+        /// <summary>
+        /// Gets the Availability Rule URL for a specific rule.
+        /// </summary>
+        /// <value>The Availability Rule URL for a specific rule.</value>
+        public string AvailabilityRuleUrl { get; private set; }
     }
 }

--- a/test/Cronofy.Test/CronofyAccountClientTests/DeleteAvailabilityRule.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/DeleteAvailabilityRule.cs
@@ -1,0 +1,21 @@
+namespace Cronofy.Test.CronofyAccountClientTests
+{
+    using NUnit.Framework;
+
+    internal sealed class DeleteAvailabilityRule : Base
+    {
+        private const string AvailabilityRuleId = "my_really_cool_rule_id";
+
+        [Test]
+        public void CanDeleteAvailabilityRule()
+        {
+            this.Http.Stub(
+                HttpDelete
+                    .Url("https://api.cronofy.com/v1/availability_rules/" + AvailabilityRuleId)
+                    .RequestHeader("Authorization", "Bearer " + AccessToken)
+                    .ResponseCode(202));
+
+            this.Client.DeleteAvailabilityRule(AvailabilityRuleId);
+        }
+    }
+}

--- a/test/Cronofy.Test/CronofyAccountClientTests/GetAvailabilityRule.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/GetAvailabilityRule.cs
@@ -16,30 +16,32 @@ namespace Cronofy.Test.CronofyAccountClientTests
                     .ResponseCode(200)
                     .ResponseBodyFormat(
                         @"
-                          {{
-                              ""availability_rule_id"": ""{0}"",
-                              ""tzid"": ""America/Chicago"",
-                              ""calendar_ids"": [
-                                  ""cal_n23kjnwrw2_jsdfjksn234""
-                              ],
-                              ""weekly_periods"": [
-                                  {{
-                                      ""day"": ""monday"",
-                                      ""start_time"": ""09:30"",
-                                      ""end_time"": ""12:30""
-                                  }},
-                                  {{
-                                      ""day"": ""monday"",
-                                      ""start_time"": ""14:00"",
-                                      ""end_time"": ""17:00""
-                                  }},
-                                  {{
-                                      ""day"": ""wednesday"",
-                                      ""start_time"": ""09:30"",
-                                      ""end_time"": ""12:30""
-                                  }}
-                              ]
-                          }}
+                            {{
+                                ""availability_rule"": {{
+                                    ""availability_rule_id"": ""{0}"",
+                                    ""tzid"": ""America/Chicago"",
+                                    ""calendar_ids"": [
+                                        ""cal_n23kjnwrw2_jsdfjksn234""
+                                    ],
+                                    ""weekly_periods"": [
+                                        {{
+                                            ""day"": ""monday"",
+                                            ""start_time"": ""09:30"",
+                                            ""end_time"": ""12:30""
+                                        }},
+                                        {{
+                                            ""day"": ""monday"",
+                                            ""start_time"": ""14:00"",
+                                            ""end_time"": ""17:00""
+                                        }},
+                                        {{
+                                            ""day"": ""wednesday"",
+                                            ""start_time"": ""09:30"",
+                                            ""end_time"": ""12:30""
+                                        }}
+                                    ]
+                                }}
+                            }}
                         ", AvailabilityRuleId));
 
             var actualResponse = this.Client.GetAvailabilityRule(AvailabilityRuleId);

--- a/test/Cronofy.Test/CronofyAccountClientTests/GetAvailabilityRule.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/GetAvailabilityRule.cs
@@ -77,5 +77,73 @@ namespace Cronofy.Test.CronofyAccountClientTests
 
             Assert.AreEqual(expectedResponse, actualResponse);
         }
+
+        [Test]
+        public void CanGetAvailabilityRuleWithMissingCalendarIds()
+        {
+            this.Http.Stub(
+                HttpGet
+                    .Url("https://api.cronofy.com/v1/availability_rules/" + AvailabilityRuleId)
+                    .RequestHeader("Authorization", "Bearer " + AccessToken)
+                    .ResponseCode(200)
+                    .ResponseBodyFormat(
+                        @"
+                            {{
+                                ""availability_rule"": {{
+                                    ""availability_rule_id"": ""{0}"",
+                                    ""tzid"": ""America/Chicago"",
+                                    ""weekly_periods"": [
+                                        {{
+                                            ""day"": ""monday"",
+                                            ""start_time"": ""09:30"",
+                                            ""end_time"": ""12:30""
+                                        }},
+                                        {{
+                                            ""day"": ""monday"",
+                                            ""start_time"": ""14:00"",
+                                            ""end_time"": ""17:00""
+                                        }},
+                                        {{
+                                            ""day"": ""wednesday"",
+                                            ""start_time"": ""09:30"",
+                                            ""end_time"": ""12:30""
+                                        }}
+                                    ]
+                                }}
+                            }}
+                        ", AvailabilityRuleId));
+
+            var actualResponse = this.Client.GetAvailabilityRule(AvailabilityRuleId);
+
+            var expectedResponse = new AvailabilityRule
+            {
+                AvailabilityRuleId = AvailabilityRuleId,
+                TimeZoneId = "America/Chicago",
+                CalendarIds = null,
+                WeeklyPeriods = new[]
+                {
+                    new AvailabilityRule.WeeklyPeriod
+                    {
+                        Day = DayOfWeek.Monday,
+                        StartTime = "09:30",
+                        EndTime = "12:30",
+                    },
+                    new AvailabilityRule.WeeklyPeriod
+                    {
+                        Day = DayOfWeek.Monday,
+                        StartTime = "14:00",
+                        EndTime = "17:00",
+                    },
+                    new AvailabilityRule.WeeklyPeriod
+                    {
+                        Day = DayOfWeek.Wednesday,
+                        StartTime = "09:30",
+                        EndTime = "12:30",
+                    },
+                },
+            };
+
+            Assert.AreEqual(expectedResponse, actualResponse);
+        }
     }
 }

--- a/test/Cronofy.Test/CronofyAccountClientTests/GetAvailabilityRule.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/GetAvailabilityRule.cs
@@ -1,5 +1,6 @@
 namespace Cronofy.Test.CronofyAccountClientTests
 {
+    using System;
     using NUnit.Framework;
 
     internal sealed class GetAvailabilityRule : Base
@@ -55,19 +56,19 @@ namespace Cronofy.Test.CronofyAccountClientTests
                 {
                     new AvailabilityRule.WeeklyPeriod
                     {
-                        Day = "monday",
+                        Day = DayOfWeek.Monday,
                         StartTime = "09:30",
                         EndTime = "12:30",
                     },
                     new AvailabilityRule.WeeklyPeriod
                     {
-                        Day = "monday",
+                        Day = DayOfWeek.Monday,
                         StartTime = "14:00",
                         EndTime = "17:00",
                     },
                     new AvailabilityRule.WeeklyPeriod
                     {
-                        Day = "wednesday",
+                        Day = DayOfWeek.Wednesday,
                         StartTime = "09:30",
                         EndTime = "12:30",
                     },

--- a/test/Cronofy.Test/CronofyAccountClientTests/GetAvailabilityRule.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/GetAvailabilityRule.cs
@@ -1,0 +1,78 @@
+namespace Cronofy.Test.CronofyAccountClientTests
+{
+    using NUnit.Framework;
+
+    internal sealed class GetAvailabilityRule : Base
+    {
+        private const string AvailabilityRuleId = "my_really_cool_rule_id";
+
+        [Test]
+        public void CanGetAvailabilityRule()
+        {
+            this.Http.Stub(
+                HttpGet
+                    .Url("https://api.cronofy.com/v1/availability_rules/" + AvailabilityRuleId)
+                    .RequestHeader("Authorization", "Bearer " + AccessToken)
+                    .ResponseCode(200)
+                    .ResponseBodyFormat(
+                        @"
+                          {{
+                              ""availability_rule_id"": ""{0}"",
+                              ""tzid"": ""America/Chicago"",
+                              ""calendar_ids"": [
+                                  ""cal_n23kjnwrw2_jsdfjksn234""
+                              ],
+                              ""weekly_periods"": [
+                                  {{
+                                      ""day"": ""monday"",
+                                      ""start_time"": ""09:30"",
+                                      ""end_time"": ""12:30""
+                                  }},
+                                  {{
+                                      ""day"": ""monday"",
+                                      ""start_time"": ""14:00"",
+                                      ""end_time"": ""17:00""
+                                  }},
+                                  {{
+                                      ""day"": ""wednesday"",
+                                      ""start_time"": ""09:30"",
+                                      ""end_time"": ""12:30""
+                                  }}
+                              ]
+                          }}
+                        ", AvailabilityRuleId));
+
+            var actualResponse = this.Client.GetAvailabilityRule(AvailabilityRuleId);
+
+            var expectedResponse = new AvailabilityRule
+            {
+                AvailabilityRuleId = AvailabilityRuleId,
+                TimeZoneId = "America/Chicago",
+                CalendarIds = new[] { "cal_n23kjnwrw2_jsdfjksn234" },
+                WeeklyPeriods = new[]
+                {
+                    new AvailabilityRule.WeeklyPeriod
+                    {
+                        Day = "monday",
+                        StartTime = "09:30",
+                        EndTime = "12:30",
+                    },
+                    new AvailabilityRule.WeeklyPeriod
+                    {
+                        Day = "monday",
+                        StartTime = "14:00",
+                        EndTime = "17:00",
+                    },
+                    new AvailabilityRule.WeeklyPeriod
+                    {
+                        Day = "wednesday",
+                        StartTime = "09:30",
+                        EndTime = "12:30",
+                    },
+                },
+            };
+
+            Assert.AreEqual(expectedResponse, actualResponse);
+        }
+    }
+}

--- a/test/Cronofy.Test/CronofyAccountClientTests/ListAvailabilityRules.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/ListAvailabilityRules.cs
@@ -59,6 +59,17 @@ namespace Cronofy.Test.CronofyAccountClientTests
                                             ""end_time"": ""17:40""
                                         }
                                     ]
+                                },
+                                {
+                                    ""availability_rule_id"": ""null_calendar_ids"",
+                                    ""tzid"": ""Europe/London"",
+                                    ""weekly_periods"": [
+                                        {
+                                            ""day"": ""thursday"",
+                                            ""start_time"": ""09:00"",
+                                            ""end_time"": ""17:30""
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -117,6 +128,21 @@ namespace Cronofy.Test.CronofyAccountClientTests
                             Day = DayOfWeek.Sunday,
                             StartTime = "11:00",
                             EndTime = "17:40",
+                        },
+                    },
+                },
+                new AvailabilityRule
+                {
+                    AvailabilityRuleId = "null_calendar_ids",
+                    TimeZoneId = "Europe/London",
+                    CalendarIds = null,
+                    WeeklyPeriods = new[]
+                    {
+                        new AvailabilityRule.WeeklyPeriod
+                        {
+                            Day = DayOfWeek.Thursday,
+                            StartTime = "09:00",
+                            EndTime = "17:30",
                         },
                     },
                 },

--- a/test/Cronofy.Test/CronofyAccountClientTests/ListAvailabilityRules.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/ListAvailabilityRules.cs
@@ -1,5 +1,6 @@
 namespace Cronofy.Test.CronofyAccountClientTests
 {
+    using System;
     using NUnit.Framework;
 
     internal sealed class ListAvailabilityRules : Base
@@ -76,19 +77,19 @@ namespace Cronofy.Test.CronofyAccountClientTests
                     {
                         new AvailabilityRule.WeeklyPeriod
                         {
-                            Day = "monday",
+                            Day = DayOfWeek.Monday,
                             StartTime = "09:30",
                             EndTime = "12:30",
                         },
                         new AvailabilityRule.WeeklyPeriod
                         {
-                            Day = "monday",
+                            Day = DayOfWeek.Monday,
                             StartTime = "14:00",
                             EndTime = "17:00",
                         },
                         new AvailabilityRule.WeeklyPeriod
                         {
-                            Day = "wednesday",
+                            Day = DayOfWeek.Wednesday,
                             StartTime = "09:30",
                             EndTime = "12:30",
                         },
@@ -107,13 +108,13 @@ namespace Cronofy.Test.CronofyAccountClientTests
                     {
                         new AvailabilityRule.WeeklyPeriod
                         {
-                            Day = "saturday",
+                            Day = DayOfWeek.Saturday,
                             StartTime = "09:00",
                             EndTime = "17:30",
                         },
                         new AvailabilityRule.WeeklyPeriod
                         {
-                            Day = "sunday",
+                            Day = DayOfWeek.Sunday,
                             StartTime = "11:00",
                             EndTime = "17:40",
                         },

--- a/test/Cronofy.Test/CronofyAccountClientTests/ListAvailabilityRules.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/ListAvailabilityRules.cs
@@ -1,0 +1,127 @@
+namespace Cronofy.Test.CronofyAccountClientTests
+{
+    using NUnit.Framework;
+
+    internal sealed class ListAvailabilityRules : Base
+    {
+        [Test]
+        public void CanListAvailabilityRules()
+        {
+            this.Http.Stub(
+                HttpGet
+                    .Url("https://api.cronofy.com/v1/availability_rules")
+                    .RequestHeader("Authorization", "Bearer " + AccessToken)
+                    .ResponseCode(200)
+                    .ResponseBody(@"
+                        {
+                            ""availability_rules"": [
+                                {
+                                    ""availability_rule_id"": ""default"",
+                                    ""tzid"": ""America/Chicago"",
+                                    ""calendar_ids"": [
+                                        ""cal_n23kjnwrw2_jsdfjksn234""
+                                    ],
+                                    ""weekly_periods"": [
+                                        {
+                                            ""day"": ""monday"",
+                                            ""start_time"": ""09:30"",
+                                            ""end_time"": ""12:30""
+                                        },
+                                        {
+                                            ""day"": ""monday"",
+                                            ""start_time"": ""14:00"",
+                                            ""end_time"": ""17:00""
+                                        },
+                                        {
+                                            ""day"": ""wednesday"",
+                                            ""start_time"": ""09:30"",
+                                            ""end_time"": ""12:30""
+                                        }
+                                    ]
+                                },
+                                {
+                                    ""availability_rule_id"": ""another_rule"",
+                                    ""tzid"": ""Europe/London"",
+                                    ""calendar_ids"": [
+                                        ""cal_n23kjnwrw2_jsdfjksn234"",
+                                        ""cal_n23kjnwrw2_th53tksn567"",
+                                    ],
+                                    ""weekly_periods"": [
+                                        {
+                                            ""day"": ""saturday"",
+                                            ""start_time"": ""09:00"",
+                                            ""end_time"": ""17:30""
+                                        },
+                                        {
+                                            ""day"": ""sunday"",
+                                            ""start_time"": ""11:00"",
+                                            ""end_time"": ""17:40""
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    "));
+
+            var actualResponse = this.Client.GetAvailabilityRules();
+
+            var expectedResponse = new[]
+            {
+                new AvailabilityRule
+                {
+                    AvailabilityRuleId = "default",
+                    TimeZoneId = "America/Chicago",
+                    CalendarIds = new[] { "cal_n23kjnwrw2_jsdfjksn234" },
+                    WeeklyPeriods = new[]
+                    {
+                        new AvailabilityRule.WeeklyPeriod
+                        {
+                            Day = "monday",
+                            StartTime = "09:30",
+                            EndTime = "12:30",
+                        },
+                        new AvailabilityRule.WeeklyPeriod
+                        {
+                            Day = "monday",
+                            StartTime = "14:00",
+                            EndTime = "17:00",
+                        },
+                        new AvailabilityRule.WeeklyPeriod
+                        {
+                            Day = "wednesday",
+                            StartTime = "09:30",
+                            EndTime = "12:30",
+                        },
+                    },
+                },
+                new AvailabilityRule
+                {
+                    AvailabilityRuleId = "another_rule",
+                    TimeZoneId = "Europe/London",
+                    CalendarIds = new[]
+                    {
+                      "cal_n23kjnwrw2_jsdfjksn234",
+                      "cal_n23kjnwrw2_th53tksn567",
+                    },
+                    WeeklyPeriods = new[]
+                    {
+                        new AvailabilityRule.WeeklyPeriod
+                        {
+                            Day = "saturday",
+                            StartTime = "09:00",
+                            EndTime = "17:30",
+                        },
+                        new AvailabilityRule.WeeklyPeriod
+                        {
+                            Day = "sunday",
+                            StartTime = "11:00",
+                            EndTime = "17:40",
+                        },
+                    },
+                },
+            };
+
+            Assert.AreEqual(expectedResponse, actualResponse);
+        }
+    }
+}

--- a/test/Cronofy.Test/CronofyAccountClientTests/UpsertAvailabilityRule.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/UpsertAvailabilityRule.cs
@@ -1,0 +1,127 @@
+namespace Cronofy.Test.CronofyAccountClientTests
+{
+    using NUnit.Framework;
+
+    internal sealed class UpsertAvailabilityRule : Base
+    {
+        [Test]
+        public void CanUpsertAvailabilityRule()
+        {
+            this.Http.Stub(
+                HttpPost
+                    .Url("https://api.cronofy.com/v1/availability_rules")
+                    .RequestHeader("Authorization", "Bearer " + AccessToken)
+                    .JsonRequest(@"
+                        {
+                            ""availability_rule_id"": ""default"",
+                            ""tzid"": ""America/Chicago"",
+                            ""calendar_ids"": [
+                                ""cal_n23kjnwrw2_jsdfjksn234""
+                            ],
+                            ""weekly_periods"": [
+                                {
+                                    ""day"": ""monday"",
+                                    ""start_time"": ""09:30"",
+                                    ""end_time"": ""12:30""
+                                },
+                                {
+                                    ""day"": ""monday"",
+                                    ""start_time"": ""14:00"",
+                                    ""end_time"": ""17:00""
+                                },
+                                {
+                                    ""day"": ""wednesday"",
+                                    ""start_time"": ""09:30"",
+                                    ""end_time"": ""12:30""
+                                }
+                            ]
+                        }
+                    ")
+                    .ResponseCode(200)
+                    .ResponseBody(@"
+                        {
+                            ""availability_rule_id"": ""default"",
+                            ""tzid"": ""America/Chicago"",
+                            ""calendar_ids"": [
+                                ""cal_n23kjnwrw2_jsdfjksn234""
+                            ],
+                            ""weekly_periods"": [
+                                {
+                                    ""day"": ""monday"",
+                                    ""start_time"": ""09:30"",
+                                    ""end_time"": ""12:30""
+                                },
+                                {
+                                    ""day"": ""monday"",
+                                    ""start_time"": ""14:00"",
+                                    ""end_time"": ""17:00""
+                                },
+                                {
+                                    ""day"": ""wednesday"",
+                                    ""start_time"": ""09:30"",
+                                    ""end_time"": ""12:30""
+                                }
+                            ]
+                        }
+                    "));
+
+            var actualResponse = this.Client.UpsertAvailabilityRule(new Requests.UpsertAvailabilityRuleRequest
+            {
+                AvailabilityRuleId = "default",
+                TimeZoneId = "America/Chicago",
+                CalendarIds = new[] { "cal_n23kjnwrw2_jsdfjksn234" },
+                WeeklyPeriods = new[]
+                {
+                    new Requests.UpsertAvailabilityRuleRequest.WeeklyPeriod
+                    {
+                        Day = "monday",
+                        StartTime = "09:30",
+                        EndTime = "12:30",
+                    },
+                    new Requests.UpsertAvailabilityRuleRequest.WeeklyPeriod
+                    {
+                        Day = "monday",
+                        StartTime = "14:00",
+                        EndTime = "17:00",
+                    },
+                    new Requests.UpsertAvailabilityRuleRequest.WeeklyPeriod
+                    {
+                        Day = "wednesday",
+                        StartTime = "09:30",
+                        EndTime = "12:30",
+                    },
+                },
+            });
+
+            var expectedResponse = new AvailabilityRule
+            {
+                AvailabilityRuleId = "default",
+                TimeZoneId = "America/Chicago",
+                CalendarIds = new[] { "cal_n23kjnwrw2_jsdfjksn234" },
+                WeeklyPeriods = new[]
+                {
+                    new AvailabilityRule.WeeklyPeriod
+                    {
+                        Day = "monday",
+                        StartTime = "09:30",
+                        EndTime = "12:30",
+                    },
+                    new AvailabilityRule.WeeklyPeriod
+                    {
+                        Day = "monday",
+                        StartTime = "14:00",
+                        EndTime = "17:00",
+                    },
+                    new AvailabilityRule.WeeklyPeriod
+                    {
+                        Day = "wednesday",
+                        StartTime = "09:30",
+                        EndTime = "12:30",
+                    },
+                },
+            };
+
+            Assert.AreEqual(expectedResponse, actualResponse);
+        }
+    }
+}

--- a/test/Cronofy.Test/CronofyAccountClientTests/UpsertAvailabilityRule.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/UpsertAvailabilityRule.cs
@@ -40,28 +40,30 @@ namespace Cronofy.Test.CronofyAccountClientTests
                     .ResponseCode(200)
                     .ResponseBody(@"
                         {
-                            ""availability_rule_id"": ""default"",
-                            ""tzid"": ""America/Chicago"",
-                            ""calendar_ids"": [
-                                ""cal_n23kjnwrw2_jsdfjksn234""
-                            ],
-                            ""weekly_periods"": [
-                                {
-                                    ""day"": ""monday"",
-                                    ""start_time"": ""09:30"",
-                                    ""end_time"": ""12:30""
-                                },
-                                {
-                                    ""day"": ""monday"",
-                                    ""start_time"": ""14:00"",
-                                    ""end_time"": ""17:00""
-                                },
-                                {
-                                    ""day"": ""wednesday"",
-                                    ""start_time"": ""09:30"",
-                                    ""end_time"": ""12:30""
-                                }
-                            ]
+                            ""availability_rule"": {
+                                ""availability_rule_id"": ""default"",
+                                ""tzid"": ""America/Chicago"",
+                                ""calendar_ids"": [
+                                    ""cal_n23kjnwrw2_jsdfjksn234""
+                                ],
+                                ""weekly_periods"": [
+                                    {
+                                        ""day"": ""monday"",
+                                        ""start_time"": ""09:30"",
+                                        ""end_time"": ""12:30""
+                                    },
+                                    {
+                                        ""day"": ""monday"",
+                                        ""start_time"": ""14:00"",
+                                        ""end_time"": ""17:00""
+                                    },
+                                    {
+                                        ""day"": ""wednesday"",
+                                        ""start_time"": ""09:30"",
+                                        ""end_time"": ""12:30""
+                                    }
+                                ]
+                            }
                         }
                     "));
 

--- a/test/Cronofy.Test/CronofyAccountClientTests/UpsertAvailabilityRule.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/UpsertAvailabilityRule.cs
@@ -100,5 +100,95 @@ namespace Cronofy.Test.CronofyAccountClientTests
 
             Assert.AreEqual(updatedAvailabilityRuleState, actualResponse);
         }
+
+        [Test]
+        public void CanUpsertAvailabilityRuleWithMissingCalendarIds()
+        {
+            this.Http.Stub(
+                HttpPost
+                    .Url("https://api.cronofy.com/v1/availability_rules")
+                    .RequestHeader("Authorization", "Bearer " + AccessToken)
+                    .JsonRequest(@"
+                        {
+                            ""availability_rule_id"": ""default"",
+                            ""tzid"": ""America/Chicago"",
+                            ""weekly_periods"": [
+                                {
+                                    ""day"": ""monday"",
+                                    ""start_time"": ""09:30"",
+                                    ""end_time"": ""12:30""
+                                },
+                                {
+                                    ""day"": ""monday"",
+                                    ""start_time"": ""14:00"",
+                                    ""end_time"": ""17:00""
+                                },
+                                {
+                                    ""day"": ""wednesday"",
+                                    ""start_time"": ""09:30"",
+                                    ""end_time"": ""12:30""
+                                }
+                            ]
+                        }
+                    ")
+                    .ResponseCode(200)
+                    .ResponseBody(@"
+                        {
+                            ""availability_rule"": {
+                                ""availability_rule_id"": ""default"",
+                                ""tzid"": ""America/Chicago"",
+                                ""weekly_periods"": [
+                                    {
+                                        ""day"": ""monday"",
+                                        ""start_time"": ""09:30"",
+                                        ""end_time"": ""12:30""
+                                    },
+                                    {
+                                        ""day"": ""monday"",
+                                        ""start_time"": ""14:00"",
+                                        ""end_time"": ""17:00""
+                                    },
+                                    {
+                                        ""day"": ""wednesday"",
+                                        ""start_time"": ""09:30"",
+                                        ""end_time"": ""12:30""
+                                    }
+                                ]
+                            }
+                        }
+                    "));
+
+            var updatedAvailabilityRuleState = new AvailabilityRule
+            {
+                AvailabilityRuleId = "default",
+                TimeZoneId = "America/Chicago",
+                CalendarIds = null,
+                WeeklyPeriods = new[]
+                {
+                    new AvailabilityRule.WeeklyPeriod
+                    {
+                        Day = DayOfWeek.Monday,
+                        StartTime = "09:30",
+                        EndTime = "12:30",
+                    },
+                    new AvailabilityRule.WeeklyPeriod
+                    {
+                        Day = DayOfWeek.Monday,
+                        StartTime = "14:00",
+                        EndTime = "17:00",
+                    },
+                    new AvailabilityRule.WeeklyPeriod
+                    {
+                        Day = DayOfWeek.Wednesday,
+                        StartTime = "09:30",
+                        EndTime = "12:30",
+                    },
+                },
+            };
+
+            var actualResponse = this.Client.UpsertAvailabilityRule(updatedAvailabilityRuleState);
+
+            Assert.AreEqual(updatedAvailabilityRuleState, actualResponse);
+        }
     }
 }

--- a/test/Cronofy.Test/CronofyAccountClientTests/UpsertAvailabilityRule.cs
+++ b/test/Cronofy.Test/CronofyAccountClientTests/UpsertAvailabilityRule.cs
@@ -1,5 +1,6 @@
 namespace Cronofy.Test.CronofyAccountClientTests
 {
+    using System;
     using NUnit.Framework;
 
     internal sealed class UpsertAvailabilityRule : Base
@@ -67,35 +68,7 @@ namespace Cronofy.Test.CronofyAccountClientTests
                         }
                     "));
 
-            var actualResponse = this.Client.UpsertAvailabilityRule(new Requests.UpsertAvailabilityRuleRequest
-            {
-                AvailabilityRuleId = "default",
-                TimeZoneId = "America/Chicago",
-                CalendarIds = new[] { "cal_n23kjnwrw2_jsdfjksn234" },
-                WeeklyPeriods = new[]
-                {
-                    new Requests.UpsertAvailabilityRuleRequest.WeeklyPeriod
-                    {
-                        Day = "monday",
-                        StartTime = "09:30",
-                        EndTime = "12:30",
-                    },
-                    new Requests.UpsertAvailabilityRuleRequest.WeeklyPeriod
-                    {
-                        Day = "monday",
-                        StartTime = "14:00",
-                        EndTime = "17:00",
-                    },
-                    new Requests.UpsertAvailabilityRuleRequest.WeeklyPeriod
-                    {
-                        Day = "wednesday",
-                        StartTime = "09:30",
-                        EndTime = "12:30",
-                    },
-                },
-            });
-
-            var expectedResponse = new AvailabilityRule
+            var updatedAvailabilityRuleState = new AvailabilityRule
             {
                 AvailabilityRuleId = "default",
                 TimeZoneId = "America/Chicago",
@@ -104,26 +77,28 @@ namespace Cronofy.Test.CronofyAccountClientTests
                 {
                     new AvailabilityRule.WeeklyPeriod
                     {
-                        Day = "monday",
+                        Day = DayOfWeek.Monday,
                         StartTime = "09:30",
                         EndTime = "12:30",
                     },
                     new AvailabilityRule.WeeklyPeriod
                     {
-                        Day = "monday",
+                        Day = DayOfWeek.Monday,
                         StartTime = "14:00",
                         EndTime = "17:00",
                     },
                     new AvailabilityRule.WeeklyPeriod
                     {
-                        Day = "wednesday",
+                        Day = DayOfWeek.Wednesday,
                         StartTime = "09:30",
                         EndTime = "12:30",
                     },
                 },
             };
 
-            Assert.AreEqual(expectedResponse, actualResponse);
+            var actualResponse = this.Client.UpsertAvailabilityRule(updatedAvailabilityRuleState);
+
+            Assert.AreEqual(updatedAvailabilityRuleState, actualResponse);
         }
     }
 }


### PR DESCRIPTION
Adds support for the various availability rule API operations:

- GetAvailabilityRule (https://docs.cronofy.com/developers/api/scheduling/availability-rules/read-availability-rule/)
- GetAvailabilityRules (https://docs.cronofy.com/developers/api/scheduling/availability-rules/list-availability-rules/)
- UpsertAvailabilityRule (https://docs.cronofy.com/developers/api/scheduling/availability-rules/upsert-availability-rule/)
- DeleteAvailabilityRule (https://docs.cronofy.com/developers/api/scheduling/availability-rules/delete-availability-rule/)

This also includes an example showing how to use the APIs end-to-end.