### PR TITLE
Pin Ubuntu version of GH Action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on: [push,pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Run tests
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Looks like the base image for GH Actions updated and it breaks dotnets ability to find some globalization dependencies.

Fixed by pinning the base image version for now, as seen here https://github.com/actions/runner-images/issues/10989#issuecomment-2559365722